### PR TITLE
Bump compose to 1.5.0-alpha03 and compiler to 1.4.6

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -15,7 +15,7 @@
  */
 
 plugins {
-    kotlin("jvm") version "1.8.10"
+    kotlin("jvm") version "1.8.20"
 }
 
 repositories {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,9 +5,9 @@ appcompat = "1.6.1"
 arch_core_testing = "2.2.0"
 coil_compose = "2.3.0"
 compose_activity = '1.7.0'
-compose = '1.4.0'
-compose_compiler = '1.4.4'
-compose_material = '1.4.0'
+compose = '1.5.0-alpha03'
+compose_material = '1.5.0-alpha03'
+compose_compiler = '1.4.6'
 core_ktx = '1.9.0'
 espresso_core = "3.4.0"
 junit_ext = "1.1.3"
@@ -34,6 +34,7 @@ accompanist-pager = { module = "com.google.accompanist:accompanist-pager", versi
 appcompat = { module = "androidx.appcompat:appcompat", version.ref = "appcompat" }
 coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil_compose" }
 compose-activity = { module = "androidx.activity:activity-compose", version.ref = "compose_activity" }
+compose-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "compose" }
 compose-ui = { module = "androidx.compose.ui:ui", version.ref = "compose" }
 compose-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose" }
 compose-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "compose" }


### PR DESCRIPTION
The compose version 1.4.+ has performance issues on the BasicText compose component.