### PR TITLE
Implement content versioning for alternative sources

### DIFF
--- a/domain/alternative-source/core/src/commonMain/kotlin/br/alexandregpereira/hunter/domain/source/SaveAlternativeSourceContentVersionsUseCase.kt
+++ b/domain/alternative-source/core/src/commonMain/kotlin/br/alexandregpereira/hunter/domain/source/SaveAlternativeSourceContentVersionsUseCase.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Alexandre Gomes Pereira
+ * Copyright (C) 2026 Alexandre Gomes Pereira
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,16 +17,12 @@
 
 package br.alexandregpereira.hunter.domain.source
 
-import br.alexandregpereira.hunter.domain.source.model.AlternativeSource
 import kotlinx.coroutines.flow.Flow
 
-interface AlternativeSourceLocalRepository {
+class SaveAlternativeSourceContentVersionsUseCase internal constructor(
+    private val repository: AlternativeSourceLocalRepository,
+) {
 
-    fun getAlternativeSources(): Flow<List<AlternativeSource>>
-
-    fun addAlternativeSource(acronym: String): Flow<Unit>
-
-    fun removeAlternativeSource(acronym: String): Flow<Unit>
-
-    fun saveContentVersions(acronymToContentVersion: Map<String, Int>): Flow<Unit>
+    operator fun invoke(acronymToContentVersion: Map<String, Int>): Flow<Unit> =
+        repository.saveContentVersions(acronymToContentVersion)
 }

--- a/domain/alternative-source/core/src/commonMain/kotlin/br/alexandregpereira/hunter/domain/source/SyncAlternativeSourceContentVersionUseCase.kt
+++ b/domain/alternative-source/core/src/commonMain/kotlin/br/alexandregpereira/hunter/domain/source/SyncAlternativeSourceContentVersionUseCase.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2026 Alexandre Gomes Pereira
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package br.alexandregpereira.hunter.domain.source
+
+import br.alexandregpereira.hunter.domain.source.model.AlternativeSource
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.single
+
+class SyncAlternativeSourceContentVersionUseCase internal constructor(
+    private val remoteRepository: AlternativeSourceRemoteRepository,
+    private val localRepository: AlternativeSourceLocalRepository,
+    private val settingsRepository: AlternativeSourceSettingsRepository,
+) {
+
+    operator fun invoke(): Flow<Pair<Boolean, Map<String, Int>>> {
+        return settingsRepository.getLanguage().flatMapLatest { lang ->
+            flow {
+                val (remoteSources, localSources) = coroutineScope {
+                    val remoteDeferred = async { remoteRepository.getAlternativeSources(lang).single() }
+                    val localDeferred = async { localRepository.getAlternativeSources().single() }
+                    remoteDeferred.await() to localDeferred.await()
+                }
+
+                val localMap: Map<String, AlternativeSource> = localSources.associateBy { it.acronym }
+                val rollbackMap: Map<String, Int> = localMap.mapValues { it.value.contentVersion }
+
+                val changedMap: Map<String, Int> = remoteSources
+                    .filter { remote ->
+                        val local = localMap[remote.acronym]
+                        local != null && remote.contentVersion != local.contentVersion
+                    }
+                    .associate { it.acronym to it.contentVersion }
+
+                if (changedMap.isEmpty()) {
+                    emit(false to emptyMap())
+                } else {
+                    localRepository.saveContentVersions(changedMap).single()
+                    emit(true to rollbackMap)
+                }
+            }
+        }
+    }
+}

--- a/domain/alternative-source/core/src/commonMain/kotlin/br/alexandregpereira/hunter/domain/source/di/DomainModule.kt
+++ b/domain/alternative-source/core/src/commonMain/kotlin/br/alexandregpereira/hunter/domain/source/di/DomainModule.kt
@@ -21,6 +21,8 @@ import br.alexandregpereira.hunter.domain.source.AddAlternativeSourceUseCase
 import br.alexandregpereira.hunter.domain.source.GetAlternativeSourcesUseCase
 import br.alexandregpereira.hunter.domain.source.GetMonsterLoreSourcesUseCase
 import br.alexandregpereira.hunter.domain.source.RemoveAlternativeSourceUseCase
+import br.alexandregpereira.hunter.domain.source.SaveAlternativeSourceContentVersionsUseCase
+import br.alexandregpereira.hunter.domain.source.SyncAlternativeSourceContentVersionUseCase
 import org.koin.dsl.module
 
 val alternativeSourceDomainModule = module {
@@ -28,4 +30,6 @@ val alternativeSourceDomainModule = module {
     factory { GetMonsterLoreSourcesUseCase(get()) }
     factory { AddAlternativeSourceUseCase(get()) }
     factory { RemoveAlternativeSourceUseCase(get()) }
+    factory { SyncAlternativeSourceContentVersionUseCase(get(), get(), get()) }
+    factory { SaveAlternativeSourceContentVersionsUseCase(get()) }
 }

--- a/domain/alternative-source/core/src/commonMain/kotlin/br/alexandregpereira/hunter/domain/source/model/AlternativeSource.kt
+++ b/domain/alternative-source/core/src/commonMain/kotlin/br/alexandregpereira/hunter/domain/source/model/AlternativeSource.kt
@@ -24,6 +24,7 @@ data class AlternativeSource(
     val coverImageUrl: String,
     val isEnabled: Boolean,
     val isLoreEnabled: Boolean,
+    val contentVersion: Int = 0,
 ) {
     val acronym: String
         get() = source.acronym

--- a/domain/alternative-source/data/src/commonMain/kotlin/br/alexandregpereira/hunter/data/source/local/AlternativeSourceLocalDataSource.kt
+++ b/domain/alternative-source/data/src/commonMain/kotlin/br/alexandregpereira/hunter/data/source/local/AlternativeSourceLocalDataSource.kt
@@ -37,4 +37,8 @@ internal class AlternativeSourceLocalDataSource(
     fun removeAlternativeSource(acronym: String): Flow<Unit> = flow {
         emit(dao.removeAlternativeSource(acronym))
     }
+
+    fun saveContentVersion(acronym: String, contentVersion: Int): Flow<Unit> = flow {
+        emit(dao.updateContentVersion(acronym, contentVersion))
+    }
 }

--- a/domain/alternative-source/data/src/commonMain/kotlin/br/alexandregpereira/hunter/data/source/local/AlternativeSourceLocalRepositoryImpl.kt
+++ b/domain/alternative-source/data/src/commonMain/kotlin/br/alexandregpereira/hunter/data/source/local/AlternativeSourceLocalRepositoryImpl.kt
@@ -24,6 +24,7 @@ import br.alexandregpereira.hunter.domain.source.model.AlternativeSource
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 
@@ -44,5 +45,12 @@ internal class AlternativeSourceLocalRepositoryImpl(
 
     override fun removeAlternativeSource(acronym: String): Flow<Unit> {
         return localDataSource.removeAlternativeSource(acronym)
+    }
+
+    override fun saveContentVersions(acronymToContentVersion: Map<String, Int>): Flow<Unit> = flow {
+        acronymToContentVersion.forEach { (acronym, contentVersion) ->
+            localDataSource.saveContentVersion(acronym, contentVersion).collect {}
+        }
+        emit(Unit)
     }
 }

--- a/domain/alternative-source/data/src/commonMain/kotlin/br/alexandregpereira/hunter/data/source/local/dao/AlternativeSourceDao.kt
+++ b/domain/alternative-source/data/src/commonMain/kotlin/br/alexandregpereira/hunter/data/source/local/dao/AlternativeSourceDao.kt
@@ -26,4 +26,6 @@ interface AlternativeSourceDao {
     suspend fun addAlternativeSource(alternativeSource: AlternativeSourceEntity)
 
     suspend fun removeAlternativeSource(acronym: String)
+
+    suspend fun updateContentVersion(acronym: String, contentVersion: Int)
 }

--- a/domain/alternative-source/data/src/commonMain/kotlin/br/alexandregpereira/hunter/data/source/local/entity/AlternativeSourceEntity.kt
+++ b/domain/alternative-source/data/src/commonMain/kotlin/br/alexandregpereira/hunter/data/source/local/entity/AlternativeSourceEntity.kt
@@ -20,4 +20,5 @@ package br.alexandregpereira.hunter.data.source.local.entity
 data class AlternativeSourceEntity(
     val acronym: String,
     val createdAt: Long,
+    val contentVersion: Int = 0,
 )

--- a/domain/alternative-source/data/src/commonMain/kotlin/br/alexandregpereira/hunter/data/source/local/mapper/AlternativeSourceEntityMapper.kt
+++ b/domain/alternative-source/data/src/commonMain/kotlin/br/alexandregpereira/hunter/data/source/local/mapper/AlternativeSourceEntityMapper.kt
@@ -35,13 +35,15 @@ internal fun List<AlternativeSourceEntity>.toDomain(): List<AlternativeSource> {
             coverImageUrl = "",
             isEnabled = true,
             isLoreEnabled = true,
+            contentVersion = it.contentVersion,
         )
     }
 }
 
-internal fun String.toEntity(): AlternativeSourceEntity {
+internal fun String.toEntity(contentVersion: Int = 0): AlternativeSourceEntity {
     return AlternativeSourceEntity(
         acronym = this,
-        createdAt = Clock.System.now().toEpochMilliseconds()
+        createdAt = Clock.System.now().toEpochMilliseconds(),
+        contentVersion = contentVersion,
     )
 }

--- a/domain/alternative-source/data/src/commonMain/kotlin/br/alexandregpereira/hunter/data/source/remote/mapper/AlternativeSourceMapper.kt
+++ b/domain/alternative-source/data/src/commonMain/kotlin/br/alexandregpereira/hunter/data/source/remote/mapper/AlternativeSourceMapper.kt
@@ -33,7 +33,8 @@ internal fun List<AlternativeSourceDto>.toDomain(): List<AlternativeSource> {
             summary = it.summary,
             coverImageUrl = it.coverImageUrl,
             isEnabled = it.isEnabled,
-            isLoreEnabled = it.isLoreEnabled
+            isLoreEnabled = it.isLoreEnabled,
+            contentVersion = it.contentVersion,
         )
     }
 }

--- a/domain/alternative-source/data/src/commonMain/kotlin/br/alexandregpereira/hunter/data/source/remote/model/AlternativeSourceDto.kt
+++ b/domain/alternative-source/data/src/commonMain/kotlin/br/alexandregpereira/hunter/data/source/remote/model/AlternativeSourceDto.kt
@@ -34,4 +34,6 @@ data class AlternativeSourceDto(
     val isEnabled: Boolean = true,
     @SerialName("isLoreEnabled")
     val isLoreEnabled: Boolean = true,
+    @SerialName("contentVersion")
+    val contentVersion: Int = 0,
 )

--- a/domain/app/data/src/commonMain/kotlin/br/alexandregpereira/hunter/data/database/dao/AlternativeSourceDaoImpl.kt
+++ b/domain/app/data/src/commonMain/kotlin/br/alexandregpereira/hunter/data/database/dao/AlternativeSourceDaoImpl.kt
@@ -39,4 +39,8 @@ internal class AlternativeSourceDaoImpl(
     override suspend fun removeAlternativeSource(acronym: String) = withContext(dispatcher) {
         queries.deleteByAcronym(acronym)
     }
+
+    override suspend fun updateContentVersion(acronym: String, contentVersion: Int) = withContext(dispatcher) {
+        queries.updateContentVersion(contentVersion = contentVersion.toLong(), acronym = acronym)
+    }
 }

--- a/domain/app/data/src/commonMain/kotlin/br/alexandregpereira/hunter/data/database/dao/AlternativeSourceDaoMapper.kt
+++ b/domain/app/data/src/commonMain/kotlin/br/alexandregpereira/hunter/data/database/dao/AlternativeSourceDaoMapper.kt
@@ -23,13 +23,15 @@ import br.alexandregpereira.hunter.database.AlternativeSourceEntity as Alternati
 internal fun AlternativeSourceEntity.toDatabaseEntity(): AlternativeSourceDatabaseEntity {
     return AlternativeSourceDatabaseEntity(
         acronym = acronym,
-        createdAt = createdAt
+        createdAt = createdAt,
+        contentVersion = contentVersion.toLong(),
     )
 }
 
 internal fun AlternativeSourceDatabaseEntity.toLocalEntity(): AlternativeSourceEntity {
     return AlternativeSourceEntity(
         acronym = acronym,
-        createdAt = createdAt
+        createdAt = createdAt,
+        contentVersion = contentVersion.toInt(),
     )
 }

--- a/domain/app/data/src/commonMain/sqldelight/br/alexandregpereira/hunter/database/AlternativeSource.sq
+++ b/domain/app/data/src/commonMain/sqldelight/br/alexandregpereira/hunter/database/AlternativeSource.sq
@@ -1,6 +1,7 @@
 CREATE TABLE IF NOT EXISTS AlternativeSourceEntity (
     `acronym` TEXT PRIMARY KEY NOT NULL,
-    `createdAt` INTEGER NOT NULL
+    `createdAt` INTEGER NOT NULL,
+    `contentVersion` INTEGER NOT NULL DEFAULT 0
 );
 
 insert:
@@ -11,3 +12,6 @@ DELETE FROM AlternativeSourceEntity WHERE acronym = ?;
 
 getAll:
 SELECT * FROM AlternativeSourceEntity;
+
+updateContentVersion:
+UPDATE AlternativeSourceEntity SET contentVersion = :contentVersion WHERE acronym = :acronym;

--- a/domain/app/data/src/commonMain/sqldelight/migrations/29.sqm
+++ b/domain/app/data/src/commonMain/sqldelight/migrations/29.sqm
@@ -1,0 +1,1 @@
+ALTER TABLE AlternativeSourceEntity ADD COLUMN contentVersion INTEGER NOT NULL DEFAULT 0;

--- a/domain/sync/core/src/commonMain/kotlin/br/alexandregpereira/hunter/domain/sync/SyncUseCase.kt
+++ b/domain/sync/core/src/commonMain/kotlin/br/alexandregpereira/hunter/domain/sync/SyncUseCase.kt
@@ -18,10 +18,10 @@
 package br.alexandregpereira.hunter.domain.sync
 
 import br.alexandregpereira.hunter.domain.monster.lore.SyncMonstersLoreUseCase
-import br.alexandregpereira.hunter.domain.settings.GetContentVersionUseCase
 import br.alexandregpereira.hunter.domain.settings.GetLanguageUseCase
-import br.alexandregpereira.hunter.domain.settings.SaveContentVersionUseCase
 import br.alexandregpereira.hunter.domain.settings.SaveLanguageUseCase
+import br.alexandregpereira.hunter.domain.source.SaveAlternativeSourceContentVersionsUseCase
+import br.alexandregpereira.hunter.domain.source.SyncAlternativeSourceContentVersionUseCase
 import br.alexandregpereira.hunter.domain.spell.SyncSpellsUseCase
 import br.alexandregpereira.hunter.domain.sync.model.SyncStatus
 import br.alexandregpereira.hunter.domain.usecase.SyncMonstersUseCase
@@ -30,9 +30,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.single
 import kotlinx.coroutines.flow.zip
@@ -44,13 +42,11 @@ class SyncUseCase internal constructor(
     private val syncMonstersLoreUseCase: SyncMonstersLoreUseCase,
     private val getLanguageUseCase: GetLanguageUseCase,
     private val saveLanguageUseCase: SaveLanguageUseCase,
-    private val getContentVersionUseCase: GetContentVersionUseCase,
-    private val saveContentVersionUseCase: SaveContentVersionUseCase,
+    private val syncAlternativeSourceContentVersionUseCase: SyncAlternativeSourceContentVersionUseCase,
+    private val saveAlternativeSourceContentVersionsUseCase: SaveAlternativeSourceContentVersionsUseCase,
     private val isFirstTime: IsFirstTime,
     private val resetFirstTime: ResetFirstTime,
 ) {
-
-    private val contentVersion = 5
 
     operator fun invoke(forceSync: Boolean = true): Flow<SyncStatus> {
         return flow {
@@ -66,7 +62,7 @@ class SyncUseCase internal constructor(
                         )
                     }.onFailure {
                         runCatching { saveLanguageUseCase(lastLanguageRollback).single() }
-                        runCatching { saveContentVersionUseCase(lastContentVersionRollback).single() }
+                        runCatching { saveAlternativeSourceContentVersionsUseCase(lastContentVersionRollback).single() }
                     }
                 }
                 resetFirstTime()
@@ -77,7 +73,7 @@ class SyncUseCase internal constructor(
         }
     }
 
-    private fun isToSync(): Flow<Triple<Boolean, String, Int>> {
+    private fun isToSync(): Flow<Triple<Boolean, String, Map<String, Int>>> {
         return isLangSyncScenario()
             .zip(isContentVersionSyncScenario()) { (isLangSyncScenario, lastLanguageRollback), (isContentVersionSyncScenario, lastContentVersionRollback) ->
                 val isToSync = isFirstTime() || isLangSyncScenario || isContentVersionSyncScenario
@@ -91,13 +87,7 @@ class SyncUseCase internal constructor(
         }
     }
 
-    private fun isContentVersionSyncScenario(): Flow<Pair<Boolean, Int>> {
-        return getContentVersionUseCase().flatMapLatest { lastContentVersion ->
-            if (contentVersion != lastContentVersion) {
-                saveContentVersionUseCase(contentVersion).map {
-                    true to lastContentVersion
-                }
-            } else flowOf(false to lastContentVersion)
-        }
+    private fun isContentVersionSyncScenario(): Flow<Pair<Boolean, Map<String, Int>>> {
+        return syncAlternativeSourceContentVersionUseCase()
     }
 }


### PR DESCRIPTION
- Add `contentVersion` field to `AlternativeSource` domain model, DTO, and database entity.
- Update `AlternativeSourceEntity` SQL table and include a migration (v29) to add the `contentVersion` column.
- Create `SyncAlternativeSourceContentVersionUseCase` to compare remote and local content versions and identify updates.
- Create `SaveAlternativeSourceContentVersionsUseCase` to persist updated content versions locally.
- Refactor `SyncUseCase` to utilize the new alternative source versioning logic instead of a global hardcoded content version.
- Update `AlternativeSourceDao` and its implementation to support updating content versions by acronym.
- Update mappers to handle the new `contentVersion` field across data layers.