### PR TITLE
Display monster source information in monster detail screen

### DIFF
--- a/feature/monster-detail/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/detail/ui/MonsterInfo.kt
+++ b/feature/monster-detail/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/detail/ui/MonsterInfo.kt
@@ -84,6 +84,19 @@ internal fun LazyListScope.monsterInfo(
         onSpellClicked = onSpellClicked
     )
 
+    item(key = "source") {
+        MonsterOptionalSectionAlphaTransition(
+            valueToValidate = { monster -> monster.sourceName.isNotBlank() },
+            dataList = monsters,
+            pagerState = pagerState,
+        ) {
+            TextBlock(
+                title = strings.source,
+                text = it.sourceName,
+            )
+        }
+    }
+
     item(key = "space") {
         Spacer(
             modifier = Modifier

--- a/feature/monster-detail/state-holder/src/commonMain/kotlin/br/alexandregpereira/hunter/monster/detail/MonsterDetailState.kt
+++ b/feature/monster-detail/state-holder/src/commonMain/kotlin/br/alexandregpereira/hunter/monster/detail/MonsterDetailState.kt
@@ -68,6 +68,7 @@ data class MonsterState(
     val reactions: List<AbilityDescriptionState> = emptyList(),
     val spellcastings: List<SpellcastingState> = emptyList(),
     val lore: String = "",
+    val sourceName: String = "",
 ) {
 
     val type: MonsterType

--- a/feature/monster-detail/state-holder/src/commonMain/kotlin/br/alexandregpereira/hunter/monster/detail/MonsterDetailStateMapper.kt
+++ b/feature/monster-detail/state-holder/src/commonMain/kotlin/br/alexandregpereira/hunter/monster/detail/MonsterDetailStateMapper.kt
@@ -72,7 +72,8 @@ private fun Monster.asState(strings: MonsterDetailStrings): MonsterState {
         legendaryActions = legendaryActions.map { it.asState() },
         reactions = reactions.map { it.asState() },
         spellcastings = spellcastings.map { it.asState(strings) },
-        lore = lore.orEmpty()
+        lore = lore.orEmpty(),
+        sourceName = sourceName,
     )
 }
 

--- a/feature/monster-detail/state-holder/src/commonMain/kotlin/br/alexandregpereira/hunter/monster/detail/MonsterDetailStrings.kt
+++ b/feature/monster-detail/state-holder/src/commonMain/kotlin/br/alexandregpereira/hunter/monster/detail/MonsterDetailStrings.kt
@@ -63,6 +63,7 @@ interface MonsterDetailStrings {
     val resetQuestion: String
     val resetConfirmation: String
     val export: String
+    val source: String
 }
 
 internal data class MonsterDetailEnStrings(
@@ -106,6 +107,7 @@ internal data class MonsterDetailEnStrings(
     override val resetQuestion: String = "Are you sure you want to reset this monster to its original state?",
     override val resetConfirmation: String = "I'm sure",
     override val export: String = "Share",
+    override val source: String = "Source",
 ) : MonsterDetailStrings
 
 internal data class MonsterDetailPtStrings(
@@ -149,6 +151,7 @@ internal data class MonsterDetailPtStrings(
     override val resetQuestion: String = "Tem certeza que deseja restaurar esse monstro para o estado original?",
     override val resetConfirmation: String = "Tenho certeza",
     override val export: String = "Compartilhar",
+    override val source: String = "Fonte",
 ) : MonsterDetailStrings
 
 fun MonsterDetailStrings(): MonsterDetailStrings = MonsterDetailEnStrings()


### PR DESCRIPTION
- Add `sourceName` field to `MonsterDetailState` and update `MonsterDetailStateMapper` to populate it.
- Implement a new "Source" section in the `MonsterInfo` compose UI using `MonsterOptionalSectionAlphaTransition` and `TextBlock`.
- Add localized strings for the "Source" label in both English (`Source`) and Portuguese (`Fonte`).