### PR TITLE
Add hit points, armor class, and subtitle search filters

### DIFF
--- a/feature/monster-detail/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/detail/ui/MonsterDetailScreen.kt
+++ b/feature/monster-detail/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/detail/ui/MonsterDetailScreen.kt
@@ -414,8 +414,8 @@ private fun MonsterTypeIcon(
     AlphaTransition(dataList = monsters, pagerState, modifier = modifier) { data: MonsterState ->
         MonsterTypeIcon(
             icon = data.type.toIcon(),
-            iconSize = 24.dp,
-            size = 80.dp,
+            iconSize = 32.dp,
+            size = 100.dp,
         )
     }
 }

--- a/feature/search/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/search/SearchMonsterStateMapper.kt
+++ b/feature/search/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/search/SearchMonsterStateMapper.kt
@@ -61,6 +61,7 @@ internal fun List<SearchKey>.toState(): List<SearchKeyState> {
         val symbols = when (searchKey.valueType) {
             SearchValueType.String -> listOf("=")
             SearchValueType.Boolean -> listOf("!")
+            SearchValueType.Int,
             SearchValueType.Float -> listOf(">", "<", "=")
         }
         symbols

--- a/feature/search/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/search/SearchStateHolder.kt
+++ b/feature/search/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/search/SearchStateHolder.kt
@@ -191,6 +191,7 @@ internal class SearchStateHolder(
             when (searchKey.valueType) {
                 SearchValueType.Boolean -> false
                 SearchValueType.String -> remainder.trimStart().let { it.isBlank() || it == "=" }
+                SearchValueType.Int,
                 SearchValueType.Float -> {
                     val valueStr = remainder.trimStart().removePrefix(">").removePrefix("<").removePrefix("=")
                     valueStr.isBlank() || valueStr.trim().toFloatOrNull() == null

--- a/feature/search/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/search/domain/SearchKey.kt
+++ b/feature/search/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/search/domain/SearchKey.kt
@@ -24,11 +24,14 @@ internal enum class SearchKey(
 ) {
     Name("-name", hasOnPreview = true),
     Cr("-challenge", hasOnPreview = true, valueType = SearchValueType.Float),
+    HitPoints("-hitPoints", hasOnPreview = true, valueType = SearchValueType.Int),
+    ArmorClass("-armorClass", hasOnPreview = true, valueType = SearchValueType.Int),
     Legendary("-legendaryMonster", valueType = SearchValueType.Boolean),
     Spellcaster("-spellcaster", valueType = SearchValueType.Boolean),
     Spell("-spellName"),
     Lore("-lore"),
     Type("-type", hasOnPreview = true),
+    Subtitle("-subtitle", hasOnPreview = true),
     Edited("-edited", valueType = SearchValueType.Boolean, hasOnPreview = true),
     Cloned("-cloned", valueType = SearchValueType.Boolean, hasOnPreview = true),
     Imported("-imported", valueType = SearchValueType.Boolean, hasOnPreview = true),
@@ -55,5 +58,6 @@ internal enum class SearchKey(
 internal enum class SearchValueType {
     String,
     Boolean,
-    Float
+    Float,
+    Int,
 }

--- a/feature/search/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/search/domain/SearchMonstersByUseCase.kt
+++ b/feature/search/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/search/domain/SearchMonstersByUseCase.kt
@@ -183,6 +183,7 @@ internal class SearchMonstersByUseCase internal constructor(
                     searchKey.getSearchKeyValue(delimiter = "=", trimmedValue)
                 }
                 SearchValueType.Boolean -> searchKey to "true"
+                SearchValueType.Int,
                 SearchValueType.Float -> {
                     val delimiter = when {
                         trimmedValue.contains(">") -> ">"
@@ -216,6 +217,8 @@ internal class SearchMonstersByUseCase internal constructor(
             SearchKey.Name -> containsByName(valueWithNoAccents)
             SearchKey.Type -> containsByType(valueWithNoAccents)
             SearchKey.Cr -> containsByChallengeRating(valueWithNoAccents, delimiter)
+            SearchKey.HitPoints -> containsByHitPoints(valueWithNoAccents, delimiter)
+            SearchKey.ArmorClass -> containsByArmorClass(valueWithNoAccents, delimiter)
             SearchKey.Spell -> containsBySpell(valueWithNoAccents)
             SearchKey.Legendary -> containsByLegendary()
             SearchKey.Source -> containsBySource(valueWithNoAccents)
@@ -241,12 +244,17 @@ internal class SearchMonstersByUseCase internal constructor(
             SearchKey.Action -> actions.containsByAction(valueWithNoAccents)
             SearchKey.LegendaryAction -> legendaryActions.containsByAction(valueWithNoAccents)
             SearchKey.Senses -> containsBySense(valueWithNoAccents)
+            SearchKey.Subtitle -> containsBySubtitle(valueWithNoAccents)
         }
     }
 
     private fun Monster.containsByName(value: String): Boolean {
         return name.removeAccents().contains(value, ignoreCase = true) ||
                 index.replace("-", " ").contains(value, ignoreCase = true)
+    }
+
+    private fun Monster.containsBySubtitle(value: String): Boolean {
+        return subtitle.removeAccents().contains(value, ignoreCase = true)
     }
 
     private fun Monster.containsByType(value: String): Boolean {
@@ -256,9 +264,26 @@ internal class SearchMonstersByUseCase internal constructor(
     private fun Monster.containsByChallengeRating(value: String, delimiter: String): Boolean {
         val crValue = value.toFloatOrNull() ?: return false
         return when (delimiter) {
-            ">" -> return challengeRating > crValue
-            "<" -> return challengeRating < crValue
-            else -> return challengeRating == crValue
+            ">" -> challengeRating > crValue
+            "<" -> challengeRating < crValue
+            else -> challengeRating == crValue
+        }
+    }
+
+    private fun Monster.containsByHitPoints(value: String, delimiter: String): Boolean {
+        return containsByInt(value = stats.hitPoints, compareValue = value.toIntOrNull(), delimiter)
+    }
+
+    private fun Monster.containsByArmorClass(value: String, delimiter: String): Boolean {
+        return containsByInt(value = stats.armorClass, compareValue = value.toIntOrNull(), delimiter)
+    }
+
+    private fun containsByInt(value: Int, compareValue: Int?, delimiter: String): Boolean {
+        if (compareValue == null) return false
+        return when (delimiter) {
+            ">" -> value > compareValue
+            "<" -> value < compareValue
+            else -> value == compareValue
         }
     }
 


### PR DESCRIPTION
- Add `HitPoints`, `ArmorClass`, and `Subtitle` to `SearchKey` domain.
- Implement `SearchValueType.Int` to support integer-based comparisons in search queries.
- Update `SearchMonstersByUseCase` to handle filtering by hit points, armor class, and subtitle, including support for range operators (`>`, `<`).
- Update `SearchMonsterStateMapper` and `SearchStateHolder` to support the new integer value type and its corresponding comparison symbols.
- Increase `MonsterTypeIcon` and container size in `MonsterDetailScreen`.