### PR TITLE
Implement Spells feature entry point in Settings

### DIFF
--- a/feature/settings/compose/build.gradle.kts
+++ b/feature/settings/compose/build.gradle.kts
@@ -37,6 +37,8 @@ multiplatform {
         implementation(project(":feature:monster-content-manager:event"))
         implementation(project(":feature:sync:event"))
         implementation(project(":feature:paywall:event"))
+        implementation(project(":feature:spell-compendium:event"))
+        implementation(project(":feature:spell-detail:event"))
         implementation(project(":ui:core"))
 
         implementation(libs.kotlin.coroutines.core)

--- a/feature/settings/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/settings/SettingsAnalytics.kt
+++ b/feature/settings/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/settings/SettingsAnalytics.kt
@@ -106,4 +106,10 @@ internal class SettingsAnalytics(
             eventName = "Settings - appearance settings click",
         )
     }
+
+    fun trackSpellsClick() {
+        analytics.track(
+            eventName = "Settings - spells click",
+        )
+    }
 }

--- a/feature/settings/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/settings/SettingsStateHolder.kt
+++ b/feature/settings/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/settings/SettingsStateHolder.kt
@@ -38,6 +38,11 @@ import br.alexandregpereira.hunter.paywall.event.PaywallResult
 import br.alexandregpereira.hunter.revenue.IsSessionUsageLimitReached
 import br.alexandregpereira.hunter.settings.domain.ApplyAppearanceSettings
 import br.alexandregpereira.hunter.settings.domain.GetAppearanceSettingsFromMonsters
+import br.alexandregpereira.hunter.spell.compendium.event.SpellCompendiumEvent
+import br.alexandregpereira.hunter.spell.compendium.event.SpellCompendiumEventResultDispatcher
+import br.alexandregpereira.hunter.spell.compendium.event.SpellCompendiumResult
+import br.alexandregpereira.hunter.spell.detail.event.SpellDetailEvent
+import br.alexandregpereira.hunter.spell.detail.event.SpellDetailEventDispatcher
 import br.alexandregpereira.hunter.state.MutableActionHandler
 import br.alexandregpereira.hunter.state.UiModel
 import br.alexandregpereira.hunter.sync.event.SyncEventDispatcher
@@ -71,6 +76,8 @@ internal class SettingsStateHolder(
     private val paywallEventDispatcher: EventDispatcher<PaywallEvent>,
     private val isSessionUsageLimitReached: IsSessionUsageLimitReached,
     private val paywallResultListener: EventListener<PaywallResult>,
+    private val spellCompendiumEventDispatcher: SpellCompendiumEventResultDispatcher,
+    private val spellDetailEventDispatcher: SpellDetailEventDispatcher,
 ) : UiModel<SettingsViewState>(SettingsViewState()), SettingsViewIntent,
     MutableActionHandler<SettingsViewAction> by MutableActionHandler() {
 
@@ -210,6 +217,22 @@ internal class SettingsStateHolder(
 
     override fun onSubscribePremiumClick() {
         paywallEventDispatcher.dispatchEvent(PaywallEvent.ShowPaywall)
+    }
+
+    override fun onSpellsClick() {
+        analytics.trackSpellsClick()
+        spellCompendiumEventDispatcher.dispatchEventResult(event = SpellCompendiumEvent.Show())
+            .onEach { spellCompendiumResult ->
+                when (spellCompendiumResult) {
+                    is SpellCompendiumResult.OnSpellClick -> {
+                        spellDetailEventDispatcher.dispatchEvent(
+                            SpellDetailEvent.ShowSpell(spellCompendiumResult.spellIndex)
+                        )
+                    }
+                    is SpellCompendiumResult.OnSpellLongClick -> {}
+                }
+            }
+            .launchIn(scope)
     }
 
     private fun load() {

--- a/feature/settings/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/settings/SettingsStrings.kt
+++ b/feature/settings/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/settings/SettingsStrings.kt
@@ -39,6 +39,7 @@ interface SettingsStrings {
     val imageContentScaleCrop: String
     val openGitHubProject: String
     val subscribePremium: String
+    val spells: String
 }
 
 internal data class SettingsEnStrings(
@@ -61,6 +62,7 @@ internal data class SettingsEnStrings(
     override val imageContentScaleCrop: String = "Expand the image",
     override val openGitHubProject: String = "Open GitHub Project",
     override val subscribePremium: String = "Remove ads with Premium",
+    override val spells: String = "Spells",
 ) : SettingsStrings
 
 internal data class SettingsPtStrings(
@@ -83,6 +85,7 @@ internal data class SettingsPtStrings(
     override val imageContentScaleCrop: String = "Expandir a imagem",
     override val openGitHubProject: String = "Abrir Projeto no GitHub",
     override val subscribePremium: String = "Remover anúncios com Premium",
+    override val spells: String = "Magias",
 ) : SettingsStrings
 
 internal data class SettingsEsStrings(
@@ -105,6 +108,7 @@ internal data class SettingsEsStrings(
     override val imageContentScaleCrop: String = "Expandir la imagen",
     override val openGitHubProject: String = "Abrir Proyecto en GitHub",
     override val subscribePremium: String = "Eliminar anuncios con Premium",
+    override val spells: String = "Magias",
 ) : SettingsStrings
 
 internal fun getSettingsStrings(lang: Language): SettingsStrings {

--- a/feature/settings/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/settings/SettingsViewIntent.kt
+++ b/feature/settings/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/settings/SettingsViewIntent.kt
@@ -51,4 +51,6 @@ internal interface SettingsViewIntent {
     fun onOpenGitHubProjectClick()
 
     fun onSubscribePremiumClick()
+
+    fun onSpellsClick()
 }

--- a/feature/settings/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/settings/di/Module.kt
+++ b/feature/settings/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/settings/di/Module.kt
@@ -23,6 +23,7 @@ import br.alexandregpereira.hunter.settings.SettingsAnalytics
 import br.alexandregpereira.hunter.settings.SettingsStateHolder
 import br.alexandregpereira.hunter.settings.domain.ApplyAppearanceSettings
 import br.alexandregpereira.hunter.settings.domain.GetAppearanceSettingsFromMonsters
+import br.alexandregpereira.hunter.spell.compendium.event.SpellCompendiumEventResultDispatcher
 import org.koin.dsl.module
 
 val featureSettingsModule = module {
@@ -46,6 +47,8 @@ val featureSettingsModule = module {
             paywallEventDispatcher = get<PaywallEventDispatcher>(),
             isSessionUsageLimitReached = get(),
             paywallResultListener = get<PaywallResultDispatcher>(),
+            spellCompendiumEventDispatcher = get<SpellCompendiumEventResultDispatcher>(),
+            spellDetailEventDispatcher = get(),
         )
     }
 }

--- a/feature/settings/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/settings/ui/MenuScreen.kt
+++ b/feature/settings/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/settings/ui/MenuScreen.kt
@@ -85,6 +85,13 @@ internal fun MenuScreen(
             Divider()
 
             MenuItem(
+                text = strings.spells,
+                onClick = viewIntent::onSpellsClick
+            )
+
+            Divider()
+
+            MenuItem(
                 text = strings.manageMonsterContent,
                 onClick = viewIntent::onManageMonsterContentClick
             )


### PR DESCRIPTION
- Add "Spells" menu item to the settings screen with localized strings for English, Portuguese, and Spanish.
- Update `SettingsStateHolder` to handle spell clicks, dispatching `SpellCompendiumEvent` and navigating to spell details upon selection.
- Integrate `SpellCompendiumEventResultDispatcher` and `SpellDetailEventDispatcher` into the settings DI module.
- Add `trackSpellsClick` to `SettingsAnalytics` for usage tracking.
- Update `build.gradle.kts` with new dependencies on spell compendium and spell detail event modules.