### PR TITLE
Improve focus management and keyboard behavior in SpellList

### DIFF
--- a/app/src/androidMain/AndroidManifest.xml
+++ b/app/src/androidMain/AndroidManifest.xml
@@ -33,6 +33,7 @@
         <activity
             android:name=".MainActivity"
             android:launchMode="standard"
+            android:windowSoftInputMode="adjustPan"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/feature/monster-registration/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/monster/registration/ui/MonsterRegistrationScreen.kt
+++ b/feature/monster-registration/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/monster/registration/ui/MonsterRegistrationScreen.kt
@@ -53,6 +53,7 @@ internal fun MonsterRegistrationScreen(
     AppScreen(
         isOpen = state.isOpen,
         contentPaddingValues = contentPadding,
+        swipeTriggerPercentage = .7f,
         modifier = Modifier.widthIn(
             max = maxBottomSheetWidth.takeIf { screenSize.isLandscape } ?: Dp.Unspecified
         ),

--- a/feature/spell-compendium/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/spell/compendium/ui/SpellList.kt
+++ b/feature/spell-compendium/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/spell/compendium/ui/SpellList.kt
@@ -24,12 +24,14 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.unit.dp
 import br.alexandregpereira.hunter.spell.compendium.SpellCompendiumIntent
 import br.alexandregpereira.hunter.spell.compendium.SpellCompendiumItemState
 import br.alexandregpereira.hunter.ui.compendium.Compendium
 import br.alexandregpereira.hunter.ui.compendium.CompendiumColumns
 import br.alexandregpereira.hunter.ui.compendium.CompendiumItemState
+import br.alexandregpereira.hunter.ui.compose.ClearFocusWhenScrolling
 import br.alexandregpereira.hunter.ui.compose.SchoolOfMagicState
 import br.alexandregpereira.hunter.ui.compose.SpellIconInfo
 import br.alexandregpereira.hunter.ui.compose.SpellIconSize
@@ -42,6 +44,7 @@ internal fun SpellList(
 ) {
     val items = remember(spellsGroupByLevel) { spellsGroupByLevel.toCompendiumItems() }
     val listState = rememberLazyGridState(initialFirstVisibleItemIndex = initialItemIndex)
+    ClearFocusWhenScrolling(scrollableState = listState)
     Compendium(
         items = items,
         animateItems = true,
@@ -50,13 +53,20 @@ internal fun SpellList(
     ) { item ->
         val spell = item.value as SpellCompendiumItemState
         val alpha = if (spell.selected) 0.5f else 1f
+        val focusManager = LocalFocusManager.current
         SpellIconInfo(
             name = spell.name,
             school = SchoolOfMagicState.valueOf(spell.school.name),
             size = SpellIconSize.SMALL,
             modifier = Modifier.padding(bottom = 16.dp).alpha(alpha),
-            onClick = { intent.onSpellClick(spell.index) },
-            onLongClick = { intent.onSpellLongClick(spell.index) },
+            onClick = {
+                focusManager.clearFocus()
+                intent.onSpellClick(spell.index)
+            },
+            onLongClick = {
+                focusManager.clearFocus()
+                intent.onSpellLongClick(spell.index)
+            },
         )
     }
 

--- a/feature/spell-registration/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/spell/registration/ui/SpellRegistrationScreen.kt
+++ b/feature/spell-registration/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/spell/registration/ui/SpellRegistrationScreen.kt
@@ -39,6 +39,7 @@ internal fun SpellRegistrationScreen(
 ) = AppScreen(
     isOpen = state.isOpen,
     contentPaddingValues = contentPadding,
+    swipeTriggerPercentage = .7f,
     onClose = onClose,
 ) {
     Column {


### PR DESCRIPTION
- Implement `ClearFocusWhenScrolling` in `SpellList` to automatically dismiss focus when the user scrolls.
- Update `SpellIconInfo` click and long-click listeners to explicitly clear focus using `LocalFocusManager`.
- Update `AndroidManifest.xml` to set `android:windowSoftInputMode="adjustPan"` for `MainActivity`, preventing layout resizing when the software keyboard is displayed.