### PR TITLE
Implement "Force" damage type support

### DIFF
--- a/domain/monster/core/src/commonMain/kotlin/br/alexandregpereira/hunter/domain/model/Damage.kt
+++ b/domain/monster/core/src/commonMain/kotlin/br/alexandregpereira/hunter/domain/model/Damage.kt
@@ -36,5 +36,6 @@ enum class DamageType {
     RADIANT,
     SLASHING,
     THUNDER,
+    FORCE,
     OTHER,
 }

--- a/domain/monster/data/src/commonMain/kotlin/br/alexandregpereira/hunter/data/monster/remote/mapper/DamageDtoMapper.kt
+++ b/domain/monster/data/src/commonMain/kotlin/br/alexandregpereira/hunter/data/monster/remote/mapper/DamageDtoMapper.kt
@@ -28,10 +28,13 @@ internal fun List<DamageDto>.toDomain(): List<Damage> {
 }
 
 internal fun DamageDto.asDomain(): Damage {
-    val index = this.type.name.lowercase()
+    val index = this.type.lowercase()
+    val type = runCatching {
+        DamageType.valueOf(this.type)
+    }.getOrNull() ?: DamageType.OTHER
     return Damage(
         index = index,
-        type = DamageType.valueOf(this.type.name),
+        type = type,
         name = this.name,
     )
 }

--- a/domain/monster/data/src/commonMain/kotlin/br/alexandregpereira/hunter/data/monster/remote/model/DamageDto.kt
+++ b/domain/monster/data/src/commonMain/kotlin/br/alexandregpereira/hunter/data/monster/remote/model/DamageDto.kt
@@ -25,37 +25,7 @@ data class DamageDto(
     @SerialName("index")
     val index: String,
     @SerialName("type")
-    val type: DamageTypeDto,
+    val type: String,
     @SerialName("name")
     val name: String
 )
-
-@Serializable
-enum class DamageTypeDto {
-    @SerialName("ACID")
-    ACID,
-    @SerialName("BLUDGEONING")
-    BLUDGEONING,
-    @SerialName("COLD")
-    COLD,
-    @SerialName("FIRE")
-    FIRE,
-    @SerialName("LIGHTNING")
-    LIGHTNING,
-    @SerialName("NECROTIC")
-    NECROTIC,
-    @SerialName("PIERCING")
-    PIERCING,
-    @SerialName("POISON")
-    POISON,
-    @SerialName("PSYCHIC")
-    PSYCHIC,
-    @SerialName("RADIANT")
-    RADIANT,
-    @SerialName("SLASHING")
-    SLASHING,
-    @SerialName("THUNDER")
-    THUNDER,
-    @SerialName("OTHER")
-    OTHER,
-}

--- a/feature/monster-detail/compose/src/commonMain/composeResources/drawable/ic_force.xml
+++ b/feature/monster-detail/compose/src/commonMain/composeResources/drawable/ic_force.xml
@@ -1,0 +1,21 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="512dp"
+    android:height="512dp"
+    android:viewportWidth="512"
+    android:viewportHeight="512">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="m361,0h-210l-30,30h270z"/>
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="m345,377c66.83,0 121,-54.17 121,-121s-54.17,-121 -121,-121h-178c-66.83,0 -121,54.17 -121,121s54.17,121 121,121z"/>
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="m0,60h512v45h-512z"/>
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="m151,512h210l30,-30h-270z"/>
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="m0,407h512v45h-512z"/>
+</vector>

--- a/feature/monster-detail/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/detail/ui/DamageBlock.kt
+++ b/feature/monster-detail/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/detail/ui/DamageBlock.kt
@@ -26,13 +26,13 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import org.jetbrains.compose.resources.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import br.alexandregpereira.hunter.domain.model.DamageType
 import br.alexandregpereira.hunter.monster.detail.DamageState
 import br.alexandregpereira.hunter.ui.util.toColor
+import org.jetbrains.compose.resources.painterResource
 
 @Composable
 private fun DamageBlock(
@@ -106,6 +106,7 @@ internal fun DamageType.getIconColor(): Color {
         DamageType.PSYCHIC -> colors.psychic
         DamageType.RADIANT -> colors.radiant
         DamageType.THUNDER -> colors.thunder
+        DamageType.FORCE -> colors.force
     }
 }
 
@@ -122,4 +123,5 @@ private class DamageIconColors(isDark: Boolean) {
     val bludgeoning = (if (isDark) "#E1A8A8" else "#613A3A").toColor()
     val piercing = (if (isDark) "#BAAFE2" else "#464058").toColor()
     val slashing = (if (isDark) "#9ECAEA" else "#364450").toColor()
+    val force = (if (isDark) "#5E6AD4" else "#001AFF").toColor()
 }

--- a/feature/monster-detail/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/detail/ui/IconState.kt
+++ b/feature/monster-detail/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/detail/ui/IconState.kt
@@ -26,6 +26,7 @@ import br.alexandregpereira.hunter.detail.ui.resources.ic_climbing
 import br.alexandregpereira.hunter.detail.ui.resources.ic_cold
 import br.alexandregpereira.hunter.detail.ui.resources.ic_deafened
 import br.alexandregpereira.hunter.detail.ui.resources.ic_exhausted
+import br.alexandregpereira.hunter.detail.ui.resources.ic_force
 import br.alexandregpereira.hunter.detail.ui.resources.ic_frightened
 import br.alexandregpereira.hunter.detail.ui.resources.ic_ghost
 import br.alexandregpereira.hunter.detail.ui.resources.ic_grappled
@@ -90,6 +91,7 @@ internal fun DamageType.toIcon(): DrawableResource? {
         DamageType.RADIANT -> Res.drawable.ic_radiant
         DamageType.SLASHING -> Res.drawable.ic_slashing
         DamageType.THUNDER -> Res.drawable.ic_thunder
+        DamageType.FORCE -> Res.drawable.ic_force
         DamageType.OTHER -> null
     }
 }

--- a/feature/monster-registration/state-holder/src/commonMain/kotlin/br/alexandregpereira/hunter/monster/registration/MonsterRegistrationStrings.kt
+++ b/feature/monster-registration/state-holder/src/commonMain/kotlin/br/alexandregpereira/hunter/monster/registration/MonsterRegistrationStrings.kt
@@ -55,6 +55,7 @@ interface MonsterRegistrationStrings {
     val damageTypeRadiant: String
     val damageTypeSlashing: String
     val damageTypeThunder: String
+    val damageTypeForce: String
     val damageTypeOther: String
     val conditionTypeBlinded: String
     val conditionTypeCharmed: String
@@ -174,6 +175,7 @@ internal data class MonsterRegistrationEnStrings(
     override val damageTypeRadiant: String = "Radiant",
     override val damageTypeSlashing: String = "Slashing",
     override val damageTypeThunder: String = "Thunder",
+    override val damageTypeForce: String = "Force",
     override val damageTypeOther: String = "Other",
     override val conditionTypeBlinded: String = "Blinded",
     override val conditionTypeCharmed: String = "Charmed",
@@ -293,6 +295,7 @@ internal data class MonsterRegistrationPtStrings(
     override val damageTypeRadiant: String = "Radiante",
     override val damageTypeSlashing: String = "Cortante",
     override val damageTypeThunder: String = "Trovão",
+    override val damageTypeForce: String = "Força",
     override val damageTypeOther: String = "Outro",
     override val conditionTypeBlinded: String = "Cego",
     override val conditionTypeCharmed: String = "Encantado",
@@ -414,6 +417,7 @@ internal data class MonsterRegistrationEsStrings(
     override val damageTypeRadiant: String = "Radiante",
     override val damageTypeSlashing: String = "Cortante",
     override val damageTypeThunder: String = "Trueno",
+    override val damageTypeForce: String = "Fuerza",
     override val damageTypeOther: String = "Otro",
     override val conditionTypeBlinded: String = "Cegado",
     override val conditionTypeCharmed: String = "Encantado",

--- a/feature/monster-registration/state-holder/src/commonMain/kotlin/br/alexandregpereira/hunter/monster/registration/mapper/StateMapper.kt
+++ b/feature/monster-registration/state-holder/src/commonMain/kotlin/br/alexandregpereira/hunter/monster/registration/mapper/StateMapper.kt
@@ -337,6 +337,7 @@ internal fun DamageType.name(strings: MonsterRegistrationStrings): String {
         DamageType.RADIANT -> strings.damageTypeRadiant
         DamageType.SLASHING -> strings.damageTypeSlashing
         DamageType.THUNDER -> strings.damageTypeThunder
+        DamageType.FORCE -> strings.damageTypeForce
         DamageType.OTHER -> strings.damageTypeOther
     }
 }


### PR DESCRIPTION
- Add `FORCE` to `DamageType` enum in domain model and update `DamageDto` to use a string for the damage type to improve flexibility.
- Implement `DamageDto` mapping with `runCatching` to safely handle unknown damage types, defaulting to `OTHER`.
- Add "Force" translations to `MonsterRegistrationStrings` for English, Portuguese, and Spanish.
- Add `ic_force.xml` vector icon and update `IconState` to map `DamageType.FORCE` to the new resource.
- Update `DamageBlock` UI with specific color constants and styling for the force damage type.
- Update `StateMapper` to include the new damage type in the monster registration flow.