### PR TITLE
Update ActionDto and mapper to support damageDicesV2

### DIFF
--- a/domain/monster/data/src/commonMain/kotlin/br/alexandregpereira/hunter/data/monster/remote/mapper/ActionDtoMapper.kt
+++ b/domain/monster/data/src/commonMain/kotlin/br/alexandregpereira/hunter/data/monster/remote/mapper/ActionDtoMapper.kt
@@ -27,9 +27,11 @@ import br.alexandregpereira.hunter.uuid.generateUUID
 internal fun List<ActionDto>.toDomain(): List<Action> {
     return this.map { action ->
         val uuid = generateUUID()
+        val damageDices = action.damageDices.toDamageDiceDomain()
+        val damageDicesV2 = action.damageDicesV2.toDamageDiceDomain()
         Action(
             id = "action-$uuid",
-            damageDices = action.damageDices.toDamageDiceDomain(),
+            damageDices = damageDices + damageDicesV2,
             attackBonus = action.attackBonus,
             abilityDescription = AbilityDescription(
                 name = action.name,

--- a/domain/monster/data/src/commonMain/kotlin/br/alexandregpereira/hunter/data/monster/remote/model/ActionDto.kt
+++ b/domain/monster/data/src/commonMain/kotlin/br/alexandregpereira/hunter/data/monster/remote/model/ActionDto.kt
@@ -23,13 +23,15 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class ActionDto(
     @SerialName("damage_dices")
-    val damageDices: List<DamageDiceDto>,
+    val damageDices: List<DamageDiceDto> = emptyList(),
     @SerialName("attack_bonus")
     val attackBonus: Int? = null,
     @SerialName("description")
     val description: String,
     @SerialName("name")
-    val name: String
+    val name: String,
+    @SerialName("damage_dices_v2")
+    val damageDicesV2: List<DamageDiceDto> = emptyList(),
 )
 
 @Serializable


### PR DESCRIPTION
- Update `ActionDto` to include `damage_dices_v2` and make `damage_dices` optional with a default empty list.
- Update `ActionDtoMapper` to combine both `damageDices` and `damageDicesV2` when mapping to the domain `Action` model.