### PR TITLE
Allow edit monster saving throws and conditions on actions

### DIFF
--- a/domain/condition/data/src/commonMain/kotlin/br/alexandregpereira/hunter/condition/GetCondition.kt
+++ b/domain/condition/data/src/commonMain/kotlin/br/alexandregpereira/hunter/condition/GetCondition.kt
@@ -16,7 +16,7 @@ internal class GetConditionImpl(
         }
         return runCatching {
             syncConditions()
-            getLocalCondition(index) ?: throw IllegalStateException("Condition not found")
+            getLocalCondition(index) ?: throw IllegalStateException("Condition $index not found")
         }.getOrElse { cause ->
             throw cause
         }

--- a/feature/monster-detail/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/detail/MonsterDetailBottomSheets.kt
+++ b/feature/monster-detail/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/detail/MonsterDetailBottomSheets.kt
@@ -78,15 +78,15 @@ fun MonsterDetailBottomSheets(
     )
 
     FormBottomSheet(
-        title = strings.clone,
+        title = state.strings.clone,
         formFields = listOf(
             FormField.Text(
                 key = "monsterName",
-                label = strings.cloneMonsterName,
+                label = state.strings.cloneMonsterName,
                 value = state.monsterCloneName,
             )
         ),
-        buttonText = strings.save,
+        buttonText = state.strings.save,
         opened = state.showCloneForm,
         buttonEnabled = state.monsterCloneName.isNotBlank(),
         maxWidth = maxWidth,
@@ -101,8 +101,8 @@ fun MonsterDetailBottomSheets(
 
     ConfirmationBottomSheet(
         show = state.showDeleteConfirmation,
-        description = strings.deleteQuestion,
-        buttonText = strings.deleteConfirmation,
+        description = state.strings.deleteQuestion,
+        buttonText = state.strings.deleteConfirmation,
         maxWidth = maxWidth,
         widthFraction = widthFraction,
         contentPadding = contentPadding,
@@ -112,8 +112,8 @@ fun MonsterDetailBottomSheets(
 
     ConfirmationBottomSheet(
         show = state.showResetConfirmation,
-        description = strings.resetQuestion,
-        buttonText = strings.resetConfirmation,
+        description = state.strings.resetQuestion,
+        buttonText = state.strings.resetConfirmation,
         maxWidth = maxWidth,
         widthFraction = widthFraction,
         contentPadding = contentPadding,

--- a/feature/monster-detail/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/detail/ui/AbilityDescriptionBlock.kt
+++ b/feature/monster-detail/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/detail/ui/AbilityDescriptionBlock.kt
@@ -38,7 +38,22 @@ internal fun AbilityDescriptionBlock(
     title: String,
     abilityDescriptions: List<AbilityDescriptionState>,
     modifier: Modifier = Modifier,
-    content: @Composable (index: Int) -> Unit = {}
+    onConditionClicked: (String) -> Unit = {},
+    content: @Composable (index: Int) -> Unit =  content@ { index ->
+        if (abilityDescriptions[index].savingThrows.isEmpty()
+            && abilityDescriptions[index].conditions.isEmpty()
+        ) {
+            return@content
+        }
+        ActionDamageGrid(
+            attackBonus = null,
+            damageDices = emptyList(),
+            savingThrows = abilityDescriptions[index].savingThrows,
+            conditions = abilityDescriptions[index].conditions,
+            modifier = Modifier.padding(top = 16.dp),
+            onConditionClicked = onConditionClicked,
+        )
+    }
 ) = Block(title = title, contentHorizontalPadding = 0.dp, modifier = modifier) {
 
     abilityDescriptions.forEachIndexed { index, abilityDescription ->

--- a/feature/monster-detail/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/detail/ui/MonsterInfo.kt
+++ b/feature/monster-detail/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/detail/ui/MonsterInfo.kt
@@ -317,7 +317,10 @@ private fun LazyListScope.monsterInfoPart5(
             pagerState = pagerState,
             getItemsKeys = getItemsKeys,
         ) {
-            ReactionBlock(reactions = it)
+            ReactionBlock(
+                reactions = it,
+                onConditionClicked = onConditionClicked,
+            )
         }
     }
 

--- a/feature/monster-detail/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/detail/ui/ReactionBlock.kt
+++ b/feature/monster-detail/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/detail/ui/ReactionBlock.kt
@@ -24,9 +24,11 @@ import br.alexandregpereira.hunter.monster.detail.AbilityDescriptionState
 @Composable
 internal fun ReactionBlock(
     reactions: List<AbilityDescriptionState>,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    onConditionClicked: (String) -> Unit = {},
 ) = AbilityDescriptionBlock(
     title = strings.reactions,
     abilityDescriptions = reactions,
-    modifier = modifier
+    modifier = modifier,
+    onConditionClicked = onConditionClicked,
 )

--- a/feature/monster-detail/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/detail/ui/SpecialAbilityBlock.kt
+++ b/feature/monster-detail/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/detail/ui/SpecialAbilityBlock.kt
@@ -17,10 +17,8 @@
 
 package br.alexandregpereira.hunter.detail.ui
 
-import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import br.alexandregpereira.hunter.monster.detail.AbilityDescriptionState
 
 @Composable
@@ -31,19 +29,6 @@ internal fun SpecialAbilityBlock(
 ) = AbilityDescriptionBlock(
     title = strings.specialAbilities,
     abilityDescriptions = specialAbilities,
-    modifier = modifier
-) { index ->
-    if (specialAbilities[index].savingThrows.isEmpty()
-        && specialAbilities[index].conditions.isEmpty()
-    ) {
-        return@AbilityDescriptionBlock
-    }
-    ActionDamageGrid(
-        attackBonus = null,
-        damageDices = emptyList(),
-        savingThrows = specialAbilities[index].savingThrows,
-        conditions = specialAbilities[index].conditions,
-        modifier = Modifier.padding(top = 16.dp),
-        onConditionClicked = onConditionClicked,
-    )
-}
+    modifier = modifier,
+    onConditionClicked = onConditionClicked,
+)

--- a/feature/monster-detail/state-holder/src/commonMain/kotlin/br/alexandregpereira/hunter/monster/detail/MonsterDetailStateHolder.kt
+++ b/feature/monster-detail/state-holder/src/commonMain/kotlin/br/alexandregpereira/hunter/monster/detail/MonsterDetailStateHolder.kt
@@ -325,7 +325,8 @@ class MonsterDetailStateHolder internal constructor(
         flow {
             emit(getCondition(conditionIndex))
         }.flowOn(dispatcher)
-            .catch {
+            .catch { cause ->
+                analytics.logException(cause)
                 setState { copy(selectedCondition = ConditionLoadingState.Error(conditionIndex)) }
             }
             .onEach { condition ->

--- a/feature/monster-registration/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/monster/registration/ui/form/MonsterAbilityDescriptionForm.kt
+++ b/feature/monster-registration/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/monster/registration/ui/form/MonsterAbilityDescriptionForm.kt
@@ -62,5 +62,27 @@ internal fun LazyListScope.MonsterAbilityDescriptionForm(
                 }
             )
         }
+
+        MonsterSavingThrowsFormItems(
+            keys = keys,
+            savingThrows = abilityDescription.savingThrows,
+            addText = { strings.addDifficultClass },
+            removeText = { strings.removeDifficultClass },
+            typeLabel = { strings.difficultClassType },
+            modifierLabel = { strings.difficultClassValue },
+            onChanged = { newThrows ->
+                onChanged(newAbilityDescriptions.changeAt(index) { copy(savingThrows = newThrows) })
+            }
+        )
+
+        MonsterConditionsFormItems(
+            keys = keys,
+            conditions = abilityDescription.conditions,
+            addText = { strings.addCondition },
+            removeText = { strings.removeCondition },
+            onChanged = { newConditions ->
+                onChanged(newAbilityDescriptions.changeAt(index) { copy(conditions = newConditions) })
+            }
+        )
     }
 }

--- a/feature/monster-registration/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/monster/registration/ui/form/MonsterActionsForm.kt
+++ b/feature/monster-registration/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/monster/registration/ui/form/MonsterActionsForm.kt
@@ -132,6 +132,36 @@ internal fun LazyListScope.MonsterActionsForm(
                 )
             }
         }
+
+        MonsterSavingThrowsFormItems(
+            keys = keys,
+            savingThrows = action.abilityDescription.savingThrows,
+            addText = { strings.addDifficultClass },
+            removeText = { strings.removeDifficultClass },
+            typeLabel = { strings.difficultClassType },
+            modifierLabel = { strings.difficultClassValue },
+            onChanged = {
+                onChanged(
+                    newActions.changeAt(actionIndex) {
+                        copy(abilityDescription = abilityDescription.copy(savingThrows = it))
+                    }
+                )
+            }
+        )
+
+        MonsterConditionsFormItems(
+            keys = keys,
+            conditions = abilityDescription.conditions,
+            addText = { strings.addCondition },
+            removeText = { strings.removeCondition },
+            onChanged = {
+                onChanged(
+                    newActions.changeAt(actionIndex) {
+                        copy(abilityDescription = abilityDescription.copy(conditions = it))
+                    }
+                )
+            }
+        )
     }
 }
 

--- a/feature/monster-registration/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/monster/registration/ui/form/MonsterConditionsForm.kt
+++ b/feature/monster-registration/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/monster/registration/ui/form/MonsterConditionsForm.kt
@@ -17,16 +17,11 @@
 
 package br.alexandregpereira.hunter.monster.registration.ui.form
 
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import br.alexandregpereira.hunter.monster.registration.ConditionState
 import br.alexandregpereira.hunter.monster.registration.ui.changeAt
 import br.alexandregpereira.hunter.monster.registration.ui.strings
-import br.alexandregpereira.hunter.ui.compose.AppTextField
 import br.alexandregpereira.hunter.ui.compose.PickerField
 
 @Suppress("FunctionName")
@@ -36,41 +31,48 @@ internal fun LazyListScope.MonsterConditionsForm(
     conditions: List<ConditionState>,
     onChanged: (List<ConditionState>) -> Unit = {}
 ) {
-    val newConditions = conditions.toMutableList()
     FormLazy(
         titleKey = keys.next(),
         title = title,
     ) {
-        FormItems(
+        MonsterConditionsFormItems(
             keys = keys,
-            items = newConditions,
-            createNew = { ConditionState() },
-            onChanged = onChanged
-        ) { i, condition ->
-            formItem(key = keys.next()) {
-                PickerField(
-                    value = condition.typeName,
-                    label = strings.conditionType,
-                    options = condition.filteredOptions,
-                    onValueChange = { optionIndex ->
-                        onChanged(
-                            newConditions.changeAt(i) {
-                                copy(selectedIndex = condition.selectedIndex(optionIndex))
-                            }
-                        )
-                    }
-                )
-            }
-            formItem(key = keys.next()) {
-                AppTextField(
-                    text = condition.name,
-                    label = condition.typeName,
-                    onValueChange = { newValue ->
-                        onChanged(newConditions.changeAt(i) { copy(name = newValue) })
-                    }
-                )
-                Spacer(modifier = Modifier.height(8.dp))
-            }
+            conditions = conditions,
+            onChanged = onChanged,
+        )
+    }
+}
+
+@Suppress("FunctionName")
+internal fun LazyListScope.MonsterConditionsFormItems(
+    keys: Iterator<String>,
+    conditions: List<ConditionState>,
+    addText: @Composable () -> String = { strings.add },
+    removeText: @Composable () -> String = { strings.remove },
+    onChanged: (List<ConditionState>) -> Unit = {}
+) {
+    val newConditions = conditions.toMutableList()
+    FormItems(
+        keys = keys,
+        items = newConditions,
+        createNew = { ConditionState() },
+        addText = addText,
+        removeText = removeText,
+        onChanged = onChanged
+    ) { i, condition ->
+        formItem(key = keys.next()) {
+            PickerField(
+                value = condition.typeName,
+                label = strings.conditionType,
+                options = condition.filteredOptions,
+                onValueChange = { optionIndex ->
+                    onChanged(
+                        newConditions.changeAt(i) {
+                            copy(selectedIndex = condition.selectedIndex(optionIndex))
+                        }
+                    )
+                }
+            )
         }
     }
 }

--- a/feature/monster-registration/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/monster/registration/ui/form/MonsterSavingThrowsForm.kt
+++ b/feature/monster-registration/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/monster/registration/ui/form/MonsterSavingThrowsForm.kt
@@ -18,6 +18,7 @@
 package br.alexandregpereira.hunter.monster.registration.ui.form
 
 import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.runtime.Composable
 import br.alexandregpereira.hunter.monster.registration.SavingThrowState
 import br.alexandregpereira.hunter.monster.registration.ui.changeAt
 import br.alexandregpereira.hunter.monster.registration.ui.strings
@@ -36,41 +37,60 @@ internal fun LazyListScope.MonsterSavingThrowsForm(
         titleKey = keys.next(),
         title = { strings.savingThrows },
     ) {
-
-        FormItems(
+        MonsterSavingThrowsFormItems(
             keys = keys,
-            items = mutableSavingThrows,
-            createNew = { SavingThrowState() },
+            savingThrows = mutableSavingThrows,
             onChanged = onChanged
-        ) { i, savingThrow ->
-            formItem(key = keys.next()) {
-                PickerField(
-                    value = savingThrow.name,
-                    label = strings.name,
-                    options = savingThrow.filteredOptions,
-                    onValueChange = { optionIndex ->
-                        onChanged(
-                            mutableSavingThrows.changeAt(i) {
-                                copy(selectedIndex = savingThrow.selectedIndex(optionIndex))
-                            }
-                        )
-                    }
-                )
-            }
+        )
+    }
+}
 
-            formItem(key = keys.next()) {
-                AppTextField(
-                    value = savingThrow.modifier,
-                    label = savingThrow.name,
-                    onValueChange = { newValue ->
-                        onChanged(
-                            mutableSavingThrows.changeAt(i) {
-                                copy(modifier = newValue)
-                            }
-                        )
-                    }
-                )
-            }
+@Suppress("FunctionName")
+internal fun LazyListScope.MonsterSavingThrowsFormItems(
+    keys: Iterator<String>,
+    savingThrows: List<SavingThrowState>,
+    addText: @Composable () -> String = { strings.add },
+    removeText: @Composable () -> String = { strings.remove },
+    typeLabel: @Composable () -> String = { strings.savingThrowType },
+    modifierLabel: @Composable () -> String = { strings.savingThrowModifier },
+    onChanged: (List<SavingThrowState>) -> Unit = {},
+) {
+    val mutableSavingThrows = savingThrows.toMutableList()
+    FormItems(
+        keys = keys,
+        items = mutableSavingThrows,
+        createNew = { SavingThrowState() },
+        addText = addText,
+        removeText = removeText,
+        onChanged = onChanged
+    ) { i, savingThrow ->
+        formItem(key = keys.next()) {
+            PickerField(
+                value = savingThrow.name,
+                label = typeLabel(),
+                options = savingThrow.filteredOptions,
+                onValueChange = { optionIndex ->
+                    onChanged(
+                        mutableSavingThrows.changeAt(i) {
+                            copy(selectedIndex = savingThrow.selectedIndex(optionIndex))
+                        }
+                    )
+                }
+            )
+        }
+
+        formItem(key = keys.next()) {
+            AppTextField(
+                value = savingThrow.modifier,
+                label = modifierLabel(),
+                onValueChange = { newValue ->
+                    onChanged(
+                        mutableSavingThrows.changeAt(i) {
+                            copy(modifier = newValue)
+                        }
+                    )
+                }
+            )
         }
     }
 }

--- a/feature/monster-registration/state-holder/src/commonMain/kotlin/br/alexandregpereira/hunter/monster/registration/MonsterRegistrationState.kt
+++ b/feature/monster-registration/state-holder/src/commonMain/kotlin/br/alexandregpereira/hunter/monster/registration/MonsterRegistrationState.kt
@@ -136,11 +136,11 @@ data class ConditionState(
     val key: String = generateUUID(),
     val typeOptions: List<TypeState> = emptyList(),
     val selectedIndex: Int = 0,
-    val name: String = typeOptions.getOrNull(selectedIndex)?.name.orEmpty(),
 ) {
     private val filteredTypeOptions: List<TypeState> = typeOptions.filter { it.enabled }
     val filteredOptions: List<String> = filteredTypeOptions.map { it.name }
     val typeName: String = typeOptions.getOrNull(selectedIndex)?.name.orEmpty()
+    val name: String = typeName
 
     fun selectedIndex(filteredIndex: Int): Int {
         return filteredTypeOptions[filteredIndex].index
@@ -151,6 +151,8 @@ data class AbilityDescriptionState(
     val key: String = generateUUID(),
     val name: String = "",
     val description: String = "",
+    val savingThrows: List<SavingThrowState> = emptyList(),
+    val conditions: List<ConditionState> = emptyList(),
 )
 
 data class ActionState(

--- a/feature/monster-registration/state-holder/src/commonMain/kotlin/br/alexandregpereira/hunter/monster/registration/MonsterRegistrationStrings.kt
+++ b/feature/monster-registration/state-holder/src/commonMain/kotlin/br/alexandregpereira/hunter/monster/registration/MonsterRegistrationStrings.kt
@@ -138,6 +138,14 @@ interface MonsterRegistrationStrings {
     val imageContentScaleCrop: String
     val monsterLoreFormTitle: String
     val monsterLoreFormTitleFieldLabel: String
+    val addDifficultClass: String
+    val removeDifficultClass: String
+    val addCondition: String
+    val removeCondition: String
+    val difficultClassValue: String
+    val difficultClassType: String
+    val savingThrowType: String
+    val savingThrowModifier: String
 }
 
 internal data class MonsterRegistrationEnStrings(
@@ -258,6 +266,14 @@ internal data class MonsterRegistrationEnStrings(
     override val imageContentScaleCrop: String = "Expand the image",
     override val monsterLoreFormTitle: String = "Lore",
     override val monsterLoreFormTitleFieldLabel: String = "Title (Optional)",
+    override val addDifficultClass: String = "Add DC",
+    override val removeDifficultClass: String = "Remove DC",
+    override val addCondition: String = "Add condition",
+    override val removeCondition: String = "Remove condition",
+    override val difficultClassValue: String = "Difficult class (DC) value",
+    override val difficultClassType: String = "Difficult class (DC) type",
+    override val savingThrowType: String = "Saving throw type",
+    override val savingThrowModifier: String = "Saving throw modifier",
 ) : MonsterRegistrationStrings
 
 internal data class MonsterRegistrationPtStrings(
@@ -300,14 +316,14 @@ internal data class MonsterRegistrationPtStrings(
     override val conditionTypeBlinded: String = "Cego",
     override val conditionTypeCharmed: String = "Encantado",
     override val conditionTypeDeafened: String = "Surdo",
-    override val conditionTypeExhaustion: String = "Exausto",
+    override val conditionTypeExhaustion: String = "Exaustão",
     override val conditionTypeFrightened: String = "Amedrontado",
     override val conditionTypeGrappled: String = "Agarrado",
     override val conditionTypeParalyzed: String = "Paralisado",
     override val conditionTypePetrified: String = "Petrificado",
     override val conditionTypePoisoned: String = "Envenenado",
     override val conditionTypeProne: String = "Caído",
-    override val conditionTypeRestrained: String = "Contido",
+    override val conditionTypeRestrained: String = "Imobilizado",
     override val conditionTypeStunned: String = "Atordoado",
     override val conditionTypeUnconscious: String = "Inconsciente",
     override val name: String = "Nome",
@@ -378,6 +394,14 @@ internal data class MonsterRegistrationPtStrings(
     override val imageContentScaleCrop: String = "Expandir a imagem",
     override val monsterLoreFormTitle: String = "Mitologia",
     override val monsterLoreFormTitleFieldLabel: String = "Título (Opcional)",
+    override val addDifficultClass: String = "Adicionar CD",
+    override val removeDifficultClass: String = "Remover CD",
+    override val addCondition: String = "Adicionar condição",
+    override val removeCondition: String = "Remover condição",
+    override val difficultClassValue: String = "Valor da classe de dificuldade (CD)",
+    override val difficultClassType: String = "Tipo da classe de dificuldade (CD)",
+    override val savingThrowType: String = "Tipo de salvaguarda",
+    override val savingThrowModifier: String = "Modificador da salvaguarda",
 ) : MonsterRegistrationStrings
 
 fun MonsterRegistrationStrings(): MonsterRegistrationStrings = MonsterRegistrationEnStrings()
@@ -419,17 +443,17 @@ internal data class MonsterRegistrationEsStrings(
     override val damageTypeThunder: String = "Trueno",
     override val damageTypeForce: String = "Fuerza",
     override val damageTypeOther: String = "Otro",
-    override val conditionTypeBlinded: String = "Cegado",
+    override val conditionTypeBlinded: String = "Ciego",
     override val conditionTypeCharmed: String = "Encantado",
-    override val conditionTypeDeafened: String = "Ensordecido",
+    override val conditionTypeDeafened: String = "Sordo",
     override val conditionTypeExhaustion: String = "Agotamiento",
-    override val conditionTypeFrightened: String = "Asustado",
+    override val conditionTypeFrightened: String = "Atemorizado",
     override val conditionTypeGrappled: String = "Aferrado",
     override val conditionTypeParalyzed: String = "Paralizado",
     override val conditionTypePetrified: String = "Petrificado",
     override val conditionTypePoisoned: String = "Envenenado",
-    override val conditionTypeProne: String = "Derribado",
-    override val conditionTypeRestrained: String = "Restringido",
+    override val conditionTypeProne: String = "Caído",
+    override val conditionTypeRestrained: String = "Inmovilizado",
     override val conditionTypeStunned: String = "Aturdido",
     override val conditionTypeUnconscious: String = "Inconsciente",
     override val name: String = "Nombre",
@@ -500,6 +524,14 @@ internal data class MonsterRegistrationEsStrings(
     override val imageContentScaleCrop: String = "Expandir la imagen",
     override val monsterLoreFormTitle: String = "Historia",
     override val monsterLoreFormTitleFieldLabel: String = "Título (Opcional)",
+    override val addDifficultClass: String = "Añadir CD",
+    override val removeDifficultClass: String = "Eliminar CD",
+    override val addCondition: String = "Añadir condición",
+    override val removeCondition: String = "Eliminar condición",
+    override val difficultClassValue: String = "Valor de la clase de dificultad (CD)",
+    override val difficultClassType: String = "Tipo de clase de dificultad (CD)",
+    override val savingThrowType: String = "Tipo de tirada de salvación",
+    override val savingThrowModifier: String = "Modificador de tirada de salvación",
 ) : MonsterRegistrationStrings
 
 internal fun AppLocalization.getStrings(): MonsterRegistrationStrings {

--- a/feature/monster-registration/state-holder/src/commonMain/kotlin/br/alexandregpereira/hunter/monster/registration/domain/NormalizeMonsterUseCase.kt
+++ b/feature/monster-registration/state-holder/src/commonMain/kotlin/br/alexandregpereira/hunter/monster/registration/domain/NormalizeMonsterUseCase.kt
@@ -161,6 +161,32 @@ private fun Monster.createIndexes(): Monster {
         damageImmunities = damageImmunities.map { damageImmunity ->
             damageImmunity.copy(index = damageImmunity.type.name.normalizeIndex())
         },
+        specialAbilities = specialAbilities.normalizeAbilityDescriptionsConditionsIndexes(),
+        actions = actions.normalizeConditionsIndexes(),
+        legendaryActions = legendaryActions.normalizeConditionsIndexes(),
+        reactions = reactions.normalizeAbilityDescriptionsConditionsIndexes(),
+    )
+}
+
+private fun List<AbilityDescription>.normalizeAbilityDescriptionsConditionsIndexes(): List<AbilityDescription> {
+    return map { ability ->
+        ability.normalizeConditionsIndexes()
+    }
+}
+
+private fun List<Action>.normalizeConditionsIndexes(): List<Action> {
+    return map { action ->
+        action.copy(
+            abilityDescription = action.abilityDescription.normalizeConditionsIndexes()
+        )
+    }
+}
+
+private fun AbilityDescription.normalizeConditionsIndexes(): AbilityDescription {
+    return copy(
+        conditions = conditions.map { condition ->
+            condition.copy(index = condition.type.name.normalizeIndex())
+        }
     )
 }
 

--- a/feature/monster-registration/state-holder/src/commonMain/kotlin/br/alexandregpereira/hunter/monster/registration/mapper/MonsterMapper.kt
+++ b/feature/monster-registration/state-holder/src/commonMain/kotlin/br/alexandregpereira/hunter/monster/registration/mapper/MonsterMapper.kt
@@ -165,6 +165,8 @@ private fun AbilityDescriptionState.asDomain(): AbilityDescription {
         index = key,
         name = name,
         description = description,
+        savingThrows = savingThrows.map { it.asDomain() },
+        conditions = conditions.map { it.asDomain() },
     )
 }
 

--- a/feature/monster-registration/state-holder/src/commonMain/kotlin/br/alexandregpereira/hunter/monster/registration/mapper/StateMapper.kt
+++ b/feature/monster-registration/state-holder/src/commonMain/kotlin/br/alexandregpereira/hunter/monster/registration/mapper/StateMapper.kt
@@ -98,10 +98,10 @@ internal fun Metadata.asState(strings: MonsterRegistrationStrings): MonsterState
         },
         senses = monster.senses,
         languages = monster.languages,
-        specialAbilities = monster.specialAbilities.map { it.asState() },
+        specialAbilities = monster.specialAbilities.map { it.asState(strings) },
         actions = monster.actions.map { it.asState(strings) },
         legendaryActions = monster.legendaryActions.map { it.asState(strings) },
-        reactions = monster.reactions.map { it.asState() },
+        reactions = monster.reactions.map { it.asState(strings) },
         spellcastings = monster.spellcastings.map { it.asState(strings) },
         loreEntries = monsterLoreEntries.map { it.asState() },
     ).run { copy(keysList = createKeys()) }
@@ -200,7 +200,6 @@ private fun Condition.asState(
         typeOptions = ConditionType.entries.map {
             it.asState(strings, filteredConditionTypes)
         },
-        name = name,
     )
 }
 
@@ -215,11 +214,13 @@ private fun ConditionType.asState(
     )
 }
 
-private fun AbilityDescription.asState(): AbilityDescriptionState {
+private fun AbilityDescription.asState(strings: MonsterRegistrationStrings): AbilityDescriptionState {
     return AbilityDescriptionState(
         key = index,
         name = name,
         description = description,
+        savingThrows = savingThrows.map { it.asState(strings, AbilityScoreType.entries) },
+        conditions = conditions.map { it.asState(strings, ConditionType.entries) },
     )
 }
 
@@ -228,7 +229,7 @@ private fun Action.asState(strings: MonsterRegistrationStrings): ActionState {
         key = id,
         damageDices = damageDices.map { it.asState(strings) },
         attackBonus = attackBonus,
-        abilityDescription = abilityDescription.asState(),
+        abilityDescription = abilityDescription.asState(strings),
     )
 }
 
@@ -449,7 +450,6 @@ private fun MonsterState.createKeys(): List<String> {
             getItemKey = { it.key },
             addKeys = {
                 add("type")
-                add("name")
             }
         ).also { addAll(it) }
         add(SectionTitle.Senses.name)
@@ -459,9 +459,21 @@ private fun MonsterState.createKeys(): List<String> {
         monster.specialAbilities.createDynamicFormKeys(
             key = SectionTitle.SpecialAbilities,
             getItemKey = { it.key },
-            addKeys = {
+            addKeys = { ability ->
                 add("name")
                 add("description")
+                ability.savingThrows.createDynamicFormKeys(
+                    key = "${SectionTitle.SpecialAbilities}-savingThrows",
+                    getItemKey = { it.key },
+                    hasTitle = false,
+                    addKeys = { add("type"); add("modifier") }
+                ).also { addAll(it) }
+                ability.conditions.createDynamicFormKeys(
+                    key = "${SectionTitle.SpecialAbilities}-conditions",
+                    getItemKey = { it.key },
+                    hasTitle = false,
+                    addKeys = { add("type") }
+                ).also { addAll(it) }
             }
         ).also { addAll(it) }
         monster.actions.createDynamicFormKeys(
@@ -480,14 +492,38 @@ private fun MonsterState.createKeys(): List<String> {
                         add("value")
                     }
                 ).also { addAll(it) }
+                action.abilityDescription.savingThrows.createDynamicFormKeys(
+                    key = "${SectionTitle.Actions}-savingThrows",
+                    getItemKey = { it.key },
+                    hasTitle = false,
+                    addKeys = { add("type"); add("modifier") }
+                ).also { addAll(it) }
+                action.abilityDescription.conditions.createDynamicFormKeys(
+                    key = "${SectionTitle.Actions}-conditions",
+                    getItemKey = { it.key },
+                    hasTitle = false,
+                    addKeys = { add("type") }
+                ).also { addAll(it) }
             }
         ).also { addAll(it) }
         monster.reactions.createDynamicFormKeys(
             key = SectionTitle.Reactions,
             getItemKey = { it.key },
-            addKeys = {
+            addKeys = { reaction ->
                 add("name")
                 add("description")
+                reaction.savingThrows.createDynamicFormKeys(
+                    key = "${SectionTitle.Reactions}-savingThrows",
+                    getItemKey = { it.key },
+                    hasTitle = false,
+                    addKeys = { add("type"); add("modifier") }
+                ).also { addAll(it) }
+                reaction.conditions.createDynamicFormKeys(
+                    key = "${SectionTitle.Reactions}-conditions",
+                    getItemKey = { it.key },
+                    hasTitle = false,
+                    addKeys = { add("type") }
+                ).also { addAll(it) }
             }
         ).also { addAll(it) }
         monster.legendaryActions.createDynamicFormKeys(
@@ -505,6 +541,18 @@ private fun MonsterState.createKeys(): List<String> {
                         add("type")
                         add("value")
                     }
+                ).also { addAll(it) }
+                action.abilityDescription.savingThrows.createDynamicFormKeys(
+                    key = "${SectionTitle.LegendaryActions}-savingThrows",
+                    getItemKey = { it.key },
+                    hasTitle = false,
+                    addKeys = { add("type"); add("modifier") }
+                ).also { addAll(it) }
+                action.abilityDescription.conditions.createDynamicFormKeys(
+                    key = "${SectionTitle.LegendaryActions}-conditions",
+                    getItemKey = { it.key },
+                    hasTitle = false,
+                    addKeys = { add("type") }
                 ).also { addAll(it) }
             }
         ).also { addAll(it) }

--- a/feature/spell-compendium/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/spell/compendium/ui/SpellList.kt
+++ b/feature/spell-compendium/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/spell/compendium/ui/SpellList.kt
@@ -18,6 +18,7 @@
 package br.alexandregpereira.hunter.spell.compendium.ui
 
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -58,7 +59,7 @@ internal fun SpellList(
             name = spell.name,
             school = SchoolOfMagicState.valueOf(spell.school.name),
             size = SpellIconSize.SMALL,
-            modifier = Modifier.padding(bottom = 16.dp).alpha(alpha),
+            modifier = Modifier.width(80.dp).padding(bottom = 16.dp).alpha(alpha),
             onClick = {
                 focusManager.clearFocus()
                 intent.onSpellClick(spell.index)

--- a/ui/core/src/commonMain/kotlin/br/alexandregpereira/hunter/ui/compose/SpellIconInfo.kt
+++ b/ui/core/src/commonMain/kotlin/br/alexandregpereira/hunter/ui/compose/SpellIconInfo.kt
@@ -49,6 +49,7 @@ fun SpellIconInfo(
         painter = painterResource(school.icon),
         iconColor = iconColor.toColor(),
         iconAlpha = 1f,
+        textAlpha = 1f,
         iconSize = size.value.dp,
         modifier = modifier.animatePressed(
             pressedScale = 0.85f,


### PR DESCRIPTION
- Add support for saving throws and conditions within `AbilityDescriptionState`, enabling these fields for special abilities, actions, legendary actions, and reactions.
- Update `NormalizeMonsterUseCase` and `MonsterMapper` to handle the normalization and mapping of saving throws and conditions for all monster ability types.
- Refactor `MonsterSavingThrowsForm` and `MonsterConditionsForm` to expose reusable `FormItems` components for use within other forms.
- Update `MonsterActionsForm` and `MonsterAbilityDescriptionForm` to include UI fields for managing saving throws and conditions.
- Enhance `MonsterDetailStateHolder` and `GetCondition` with improved error logging and more descriptive exception messages.
- Update `AbilityDescriptionBlock` and its derivatives (`SpecialAbilityBlock`, `ReactionBlock`) to display a damage/condition grid when saving throws or conditions are present.
- Fix a UI issue in `SpellList` by explicitly setting a width for `SpellIconInfo` and add `textAlpha` property to `SpellIconInfo`.
- Add new localized strings for "Difficult Class" and "Saving Throw" labels in English, Portuguese, and Spanish.