### PR TITLE
Refactor `ClearFocusWhenScrolling` to be platform-specific

### DIFF
--- a/ui/core/src/androidMain/kotlin/br/alexandregpereira/hunter/ui/compose/AppTextField.android.kt
+++ b/ui/core/src/androidMain/kotlin/br/alexandregpereira/hunter/ui/compose/AppTextField.android.kt
@@ -1,0 +1,5 @@
+package br.alexandregpereira.hunter.ui.compose
+
+internal actual fun shouldEnableClearFocusWhenScrolling(): Boolean {
+    return true
+}

--- a/ui/core/src/commonMain/kotlin/br/alexandregpereira/hunter/ui/compose/AppTextField.kt
+++ b/ui/core/src/commonMain/kotlin/br/alexandregpereira/hunter/ui/compose/AppTextField.kt
@@ -191,8 +191,11 @@ enum class AppKeyboardType {
 
 @Composable
 fun ClearFocusWhenScrolling(scrollableState: ScrollableState) {
+    if (!shouldEnableClearFocusWhenScrolling()) return
     val focusManager = LocalFocusManager.current
     LaunchedEffect(scrollableState.isScrollInProgress) {
         if (scrollableState.isScrollInProgress) focusManager.clearFocus()
     }
 }
+
+internal expect fun shouldEnableClearFocusWhenScrolling(): Boolean

--- a/ui/core/src/iosMain/kotlin/br/alexandregpereira/hunter/ui/compose/AppTextField.ios.kt
+++ b/ui/core/src/iosMain/kotlin/br/alexandregpereira/hunter/ui/compose/AppTextField.ios.kt
@@ -1,0 +1,5 @@
+package br.alexandregpereira.hunter.ui.compose
+
+internal actual fun shouldEnableClearFocusWhenScrolling(): Boolean {
+    return false
+}

--- a/ui/core/src/jvmMain/kotlin/br/alexandregpereira/hunter/ui/compose/AppTextField.jvm.kt
+++ b/ui/core/src/jvmMain/kotlin/br/alexandregpereira/hunter/ui/compose/AppTextField.jvm.kt
@@ -1,0 +1,5 @@
+package br.alexandregpereira.hunter.ui.compose
+
+internal actual fun shouldEnableClearFocusWhenScrolling(): Boolean {
+    return true
+}


### PR DESCRIPTION
- Introduce `shouldEnableClearFocusWhenScrolling()` expect/actual function to control focus behavior across platforms.
- Enable focus clearing during scroll for Android and JVM.
- Disable focus clearing during scroll for iOS to align with platform-specific expectations.