### PR TITLE
Automate iOS versioning and optimize build configuration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,7 +16,6 @@
  */
 
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.util.Properties
 
 plugins {
@@ -106,6 +105,15 @@ multiplatform {
 }
 
 val (appVersionCode, appVersionName) = getVersionCodeAndVersionName()
+
+tasks.register<UpdateIosVersionTask>("updateIosVersion") {
+    versionName.set(appVersionName)
+    versionCode.set(appVersionCode)
+    iosAppDir.set(rootProject.layout.projectDirectory.dir("iosApp"))
+}
+
+tasks.matching { it.name.contains("embedAndSignAppleFrameworkForXcode") }
+    .configureEach { dependsOn("updateIosVersion") }
 
 // Load local.properties manually to ensure AMPLITUDE_API_KEY is available
 val localProps = Properties()
@@ -296,7 +304,3 @@ compose {
     }
 }
 
-// Ensure the task runs before compilation
-tasks.withType<KotlinCompile>().configureEach {
-    dependsOn("generateAppConfig")
-}

--- a/buildSrc/src/main/kotlin/UpdateIosVersionTask.kt
+++ b/buildSrc/src/main/kotlin/UpdateIosVersionTask.kt
@@ -1,0 +1,40 @@
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
+
+abstract class UpdateIosVersionTask : DefaultTask() {
+
+    @get:Input
+    abstract val versionName: Property<String>
+
+    @get:Input
+    abstract val versionCode: Property<Int>
+
+    @get:OutputDirectory
+    abstract val iosAppDir: DirectoryProperty
+
+    init {
+        description = "Updates MARKETING_VERSION and CURRENT_PROJECT_VERSION in the CocoaPods xcconfig files."
+        group = "build"
+    }
+
+    @TaskAction
+    fun update() {
+        val podsXcconfigDir = iosAppDir.get().asFile
+            .resolve("Pods/Target Support Files/Pods-MonsterCompendium")
+        if (!podsXcconfigDir.exists()) return
+
+        podsXcconfigDir.listFiles { f -> f.extension == "xcconfig" }?.forEach { xcconfig ->
+            val lines = xcconfig.readLines()
+                .filter { !it.startsWith("MARKETING_VERSION") && !it.startsWith("CURRENT_PROJECT_VERSION") }
+            val updated = (lines + listOf(
+                "MARKETING_VERSION = ${versionName.get()}",
+                "CURRENT_PROJECT_VERSION = ${versionCode.get()}",
+            )).joinToString("\n")
+            xcconfig.writeText(updated)
+        }
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,7 +27,7 @@ org.gradle.jvmargs=-Xmx8g -XX:MaxMetaspaceSize=1g -XX:G1HeapRegionSize=8M -Dfile
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-# org.gradle.parallel=true
+org.gradle.parallel=true
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app"s APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
@@ -40,6 +40,7 @@ kotlin.mpp.androidSourceSetLayoutVersion=2
 android.nonTransitiveRClass=true
 android.nonFinalResIds=true
 org.gradle.configuration-cache=true
+org.gradle.caching=true
 kotlin.native.ignoreDisabledTargets=true
 compose.kotlin.native.manageCacheKind=false
 # Look for ConsentDebugSettings.Builder().addTestDeviceHashedId in logcat to get the device id

--- a/iosApp/MonsterCompendium.xcodeproj/project.pbxproj
+++ b/iosApp/MonsterCompendium.xcodeproj/project.pbxproj
@@ -268,9 +268,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-MonsterCompendium/Pods-MonsterCompendium-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-MonsterCompendium/Pods-MonsterCompendium-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -317,24 +321,26 @@
 			);
 			outputPaths = (
 			);
-			runOnlyForDeploymentPostprocessing = 0;
+			runOnlyForDeploymentPostprocessing = 1;
 			shellPath = /bin/sh;
 			shellScript = "${PODS_ROOT}/FirebaseCrashlytics/run\n";
 		};
 		C1BC0EAD29848147002F517C /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputFileListPaths = (
 			);
 			inputPaths = (
+				"${SRCROOT}/../app/src",
+				"${SRCROOT}/../buildSrc",
 			);
 			name = "Run Script";
 			outputFileListPaths = (
 			);
 			outputPaths = (
+				"${SRCROOT}/../build/xcode-frameworks/${CONFIGURATION}/${SDK_NAME}/MonsterCompendium.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -502,8 +508,8 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_ASSET_PATHS = "\"MonsterCompendium/Preview Content\"";
 				DEVELOPMENT_TEAM = UF66T7J8P8;
@@ -525,7 +531,6 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-lsqlite3",
@@ -534,6 +539,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = br.alexandregpereira.MonsterCompendium;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -548,8 +554,8 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"MonsterCompendium/Preview Content\"";
 				DEVELOPMENT_TEAM = UF66T7J8P8;
 				ENABLE_PREVIEWS = YES;
@@ -570,7 +576,6 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-lsqlite3",
@@ -579,6 +584,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = br.alexandregpereira.MonsterCompendium;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -591,10 +597,8 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
-				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = br.alexandregpereira.MonsterCompendiumTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -610,10 +614,8 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.2;
-				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = br.alexandregpereira.MonsterCompendiumTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -628,9 +630,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = br.alexandregpereira.MonsterCompendiumUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -645,9 +645,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
-				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = br.alexandregpereira.MonsterCompendiumUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;


### PR DESCRIPTION
- Remove hardcoded `MARKETING_VERSION` and `CURRENT_PROJECT_VERSION` from `iosApp/MonsterCompendium.xcodeproj/project.pbxproj`.
- Implement `UpdateIosVersionTask.kt` in `buildSrc` to dynamically inject version name and code into CocoaPods xcconfig files.
- Register `updateIosVersion` task in `app/build.gradle.kts` and link it to the `embedAndSignAppleFrameworkForXcode` task.
- Update Xcode project build phases to include specific input/output paths for the "Run Script" phase to improve build caching.
- Enable `org.gradle.parallel` and `org.gradle.caching` in `gradle.properties` for better build performance.
- Set `runOnlyForDeploymentPostprocessing` to `1` for the Firebase Crashlytics run script.
- Ensure `CODE_SIGN_IDENTITY` is explicitly set to "Apple Development" in the iOS project.