### PR TITLE
Add Xcode Cloud pre-build script to install CocoaPods

### DIFF
--- a/iosApp/ci_scripts/ci_pre_xcodebuild.sh
+++ b/iosApp/ci_scripts/ci_pre_xcodebuild.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+
+cd $CI_WORKSPACE/iosApp
+brew install cocoapods
+pod install


### PR DESCRIPTION
- Create `iosApp/ci_scripts/ci_pre_xcodebuild.sh` to handle dependency installation in CI.
- Install `cocoapods` via Homebrew and run `pod install` within the `iosApp` directory.