### PR TITLE
Enable in-place document opening on iOS

### DIFF
--- a/iosApp/MonsterCompendium/Info.plist
+++ b/iosApp/MonsterCompendium/Info.plist
@@ -10,6 +10,8 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>LSSupportsOpeningDocumentsInPlace</key>
+	<true/>
 	<key>CFBundleDocumentTypes</key>
 	<array>
 		<dict>


### PR DESCRIPTION
- Add `LSSupportsOpeningDocumentsInPlace` key to `Info.plist` and set it to `true`.