### PR TITLE
Update Android manifest to improve .compendium file association

### DIFF
--- a/app/src/androidMain/AndroidManifest.xml
+++ b/app/src/androidMain/AndroidManifest.xml
@@ -15,8 +15,7 @@
   ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
   -->
 
-<manifest xmlns:tools="http://schemas.android.com/tools"
-    xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
@@ -49,7 +48,9 @@
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
-
+                <data
+                    android:mimeType="application/x-zip"
+                    android:scheme="content" />
                 <data
                     android:mimeType="application/octet-stream"
                     android:scheme="content" />
@@ -57,43 +58,13 @@
                     android:mimeType="application/octet-stream"
                     android:scheme="file" />
             </intent-filter>
+            <!-- Samsung My Files sends ACTION_VIEW with a MediaStore URI (content://media/external/file/<id>)
+                 and an empty MIME type for unknown extensions, so path/mimeType filters never match.
+                 This broad filter is intentionally required to support opening .compendium files from Samsung My Files. -->
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
-                <data
-                    android:host="*"
-                    android:mimeType="*/*"
-                    android:pathPattern=".*\\.compendium"
-                    android:scheme="content" />
-            </intent-filter>
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <data
-                    android:host="*"
-                    android:mimeType="*/*"
-                    android:pathPattern=".*\\.compendium"
-                    android:scheme="file" />
-            </intent-filter>
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <data
-                    android:host="*"
-                    android:mimeType="*/*"
-                    android:pathSuffix=".compendium"
-                    android:scheme="content"
-                    tools:targetApi="31" />
-            </intent-filter>
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <data
-                    android:host="*"
-                    android:mimeType="*/*"
-                    android:pathSuffix=".compendium"
-                    android:scheme="file"
-                    tools:targetApi="31" />
+                <data android:scheme="content" />
             </intent-filter>
         </activity>
 

--- a/app/src/androidMain/AndroidManifest.xml
+++ b/app/src/androidMain/AndroidManifest.xml
@@ -59,12 +59,13 @@
                     android:scheme="file" />
             </intent-filter>
             <!-- Samsung My Files sends ACTION_VIEW with a MediaStore URI (content://media/external/file/<id>)
-                 and an empty MIME type for unknown extensions, so path/mimeType filters never match.
+                 and no path containing the file extension, so pathPattern/pathSuffix filters never match.
+                 mimeType="*/*" is required — without it the filter does not match Samsung My Files intents.
                  This broad filter is intentionally required to support opening .compendium files from Samsung My Files. -->
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
-                <data android:scheme="content" />
+                <data android:mimeType="*/*" android:scheme="content" />
             </intent-filter>
         </activity>
 

--- a/app/src/androidMain/AndroidManifest.xml
+++ b/app/src/androidMain/AndroidManifest.xml
@@ -15,7 +15,8 @@
   ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
   -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:tools="http://schemas.android.com/tools"
+    xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
@@ -73,6 +74,24 @@
                     android:mimeType="*/*"
                     android:pathPattern=".*\\.compendium"
                     android:scheme="file" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data
+                    android:host="*"
+                    android:pathSuffix=".compendium"
+                    android:scheme="content"
+                    tools:targetApi="31" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data
+                    android:host="*"
+                    android:pathSuffix=".compendium"
+                    android:scheme="file"
+                    tools:targetApi="31" />
             </intent-filter>
         </activity>
 

--- a/app/src/androidMain/AndroidManifest.xml
+++ b/app/src/androidMain/AndroidManifest.xml
@@ -80,6 +80,7 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <data
                     android:host="*"
+                    android:mimeType="*/*"
                     android:pathSuffix=".compendium"
                     android:scheme="content"
                     tools:targetApi="31" />
@@ -89,6 +90,7 @@
                 <category android:name="android.intent.category.DEFAULT" />
                 <data
                     android:host="*"
+                    android:mimeType="*/*"
                     android:pathSuffix=".compendium"
                     android:scheme="file"
                     tools:targetApi="31" />


### PR DESCRIPTION
- Add `tools` namespace to the manifest to support API-specific attributes.
- Expand intent filters for the `.compendium` file extension using `pathSuffix` for both `content` and `file` schemes.
- Apply `tools:targetApi="31"` to the new intent filters to ensure better compatibility and behavior on Android 12 and above.