### PR TITLE
Improve UI animations and share content features

### DIFF
--- a/feature/monster-detail/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/detail/ui/ConditionBlock.kt
+++ b/feature/monster-detail/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/detail/ui/ConditionBlock.kt
@@ -70,7 +70,7 @@ internal fun Condition(
     painter = painterResource(condition.type.toIcon()),
     iconSize = iconSize,
     modifier = modifier.animatePressed(
-        pressedScale = .7f,
+        pressedScale = .85f,
         onClick = {
             onConditionClicked(condition.index)
         }

--- a/feature/monster-detail/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/detail/ui/DifficultyClass.kt
+++ b/feature/monster-detail/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/detail/ui/DifficultyClass.kt
@@ -22,7 +22,7 @@ internal fun DifficultyClass(
     value: Int,
     name: String,
     modifier: Modifier = Modifier,
-    iconSize: Dp = 56.dp,
+    iconSize: Dp = 48.dp,
     alpha: Float = 0.7f,
 ) = Column(
     modifier
@@ -45,7 +45,8 @@ internal fun DifficultyClass(
             Text(
                 text = value.toString(),
                 fontWeight = FontWeight.Bold,
-                fontSize = 32.sp,
+                textAlign = TextAlign.Center,
+                fontSize = 28.sp,
             )
         }
     }
@@ -62,5 +63,5 @@ internal fun DifficultyClass(
 @Preview(showBackground = true)
 @Composable
 private fun DifficultyClassPreview() = HunterTheme {
-    DifficultyClass(value = 10, name = "Dexterity")
+    DifficultyClass(value = 23, name = "Dexterity")
 }

--- a/feature/monster-detail/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/detail/ui/LoreBlock.kt
+++ b/feature/monster-detail/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/detail/ui/LoreBlock.kt
@@ -41,6 +41,9 @@ internal fun LoreBlock(
         modifier = modifier
             .padding(horizontal = 16.dp)
             .padding(bottom = 16.dp)
-            .animatePressed(onClick = onClick),
+            .animatePressed(
+                pressedScale = .95f,
+                onClick = onClick
+            ),
     )
 }

--- a/feature/share-content/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/shareContent/ShareContentImportFeature.kt
+++ b/feature/share-content/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/shareContent/ShareContentImportFeature.kt
@@ -41,7 +41,6 @@ fun ShareContentImportFeature() {
 
     val state by stateHolder.state.collectAsState()
     ShareContentImportBottomSheet(
-        isOpen = state.isOpen,
         state = state,
         onImport = stateHolder::onImport,
         onFilePickClick = stateHolder::onFilePickClick,

--- a/feature/share-content/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/shareContent/domain/CompendiumFileManager.kt
+++ b/feature/share-content/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/shareContent/domain/CompendiumFileManager.kt
@@ -154,7 +154,12 @@ internal class CompendiumFileManagerImpl(
     private fun List<String>.accumulateImages(
         monsterImages: MutableList<FileEntry>,
     ) {
-        forEach { filePath -> monsterImages.add(FileEntry(filePath)) }
+        forEach { filePath ->
+            val file = FileEntry(filePath)
+            if (file.size > 0) {
+                monsterImages.add(file)
+            }
+        }
     }
 
     private fun List<Monster>.getOriginalImagePaths(): List<String> {

--- a/feature/share-content/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/shareContent/state/ShareContentExportStateHolder.kt
+++ b/feature/share-content/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/shareContent/state/ShareContentExportStateHolder.kt
@@ -67,6 +67,7 @@ internal class ShareContentExportStateHolder(
                         copy(
                             isOpen = true,
                             isLoading = true,
+                            exportError = false,
                             strings = appLocalization.getLanguage().getExportStrings(),
                         )
                     }

--- a/feature/share-content/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/shareContent/state/ShareContentImportState.kt
+++ b/feature/share-content/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/shareContent/state/ShareContentImportState.kt
@@ -20,16 +20,15 @@ package br.alexandregpereira.hunter.shareContent.state
 internal data class ShareContentImportState(
     val isOpen: Boolean = false,
     val isLoading: Boolean = false,
-    val contentToImport: String = "",
     val importExtractedState: ShareContentExtractedState? = null,
     val importError: ShareContentImportError? = null,
     val strings: ShareContentImportStrings = ShareContentImportStrings(),
 ) {
-    val importErrorMessage: String = importError?.let {
+    val importErrorMessage: String? = importError?.let {
         when (it) {
             ShareContentImportError.InvalidContent -> strings.importInvalidContentErrorMessage
         }
-    } ?: ""
+    }
 }
 
 internal enum class ShareContentImportError {

--- a/feature/share-content/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/shareContent/state/ShareContentImportStateHolder.kt
+++ b/feature/share-content/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/shareContent/state/ShareContentImportStateHolder.kt
@@ -163,6 +163,7 @@ internal class ShareContentImportStateHolder(
 
     fun onFilePickClick() {
         analytics.track(eventName = "Import content - file pick clicked")
+        setState { copy(isLoading = true) }
         sendAction(ShareContentImportUiEvent.PickFile)
     }
 
@@ -171,6 +172,7 @@ internal class ShareContentImportStateHolder(
             analytics.track(
                 eventName = "Import content - file pick cancelled",
             )
+            setState { copy(isLoading = false) }
             return
         }
         analytics.track(
@@ -180,7 +182,7 @@ internal class ShareContentImportStateHolder(
                 "fileSize" to fileEntry.size.toString(),
             )
         )
-        setState { copy(isLoading = true, contentToImport = fileEntry.name) }
+        setState { copy(isLoading = true) }
         extractZipAndPrepareImport(zipFile = fileEntry)
     }
 

--- a/feature/share-content/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/shareContent/state/ShareContentImportStrings.kt
+++ b/feature/share-content/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/shareContent/state/ShareContentImportStrings.kt
@@ -24,6 +24,7 @@ interface ShareContentImportStrings {
     val importTitle: String
     val importInvalidContentErrorMessage: String
     val pickCompendiumFile: String
+    val pickCompendiumFileDescription: String
     val extractedStrings: ShareContentExtractedStrings
 }
 
@@ -32,6 +33,7 @@ internal data class ShareContentEnImportStrings(
     override val importTitle: String = "Import content",
     override val importInvalidContentErrorMessage: String = "Invalid content",
     override val pickCompendiumFile: String = "Pick compendium file",
+    override val pickCompendiumFileDescription: String = "Pick a .compendium file to add creatures, spells, and other content to your collection. These files are generated when you share content from Monster Compendium.",
     override val extractedStrings: ShareContentExtractedStrings = ShareContentExtractedEnStrings(),
 ) : ShareContentImportStrings
 
@@ -40,6 +42,7 @@ internal data class ShareContentPtImportStrings(
     override val importTitle: String = "Importar conteúdo",
     override val importInvalidContentErrorMessage: String = "Conteúdo inválido",
     override val pickCompendiumFile: String = "Escolher arquivo compendium",
+    override val pickCompendiumFileDescription: String = "Escolha um arquivo .compendium para adicionar criaturas, magias e outros conteúdos à sua coleção. Esses arquivos são gerados ao compartilhar conteúdo do Monster Compendium.",
     override val extractedStrings: ShareContentExtractedStrings = ShareContentExtractedPtStrings(),
 ) : ShareContentImportStrings
 
@@ -50,6 +53,7 @@ internal data class ShareContentEsImportStrings(
     override val importTitle: String = "Importar contenido",
     override val importInvalidContentErrorMessage: String = "Contenido inválido",
     override val pickCompendiumFile: String = "Elegir archivo compendium",
+    override val pickCompendiumFileDescription: String = "Elige un archivo .compendium para añadir criaturas, magias y otro contenido a tu colección. Estos archivos se generan al compartir contenido desde Monster Compendium.",
     override val extractedStrings: ShareContentExtractedStrings = ShareContentExtractedEsStrings(),
 ) : ShareContentImportStrings
 

--- a/feature/share-content/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/shareContent/ui/ShareContentExportScreen.kt
+++ b/feature/share-content/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/shareContent/ui/ShareContentExportScreen.kt
@@ -23,16 +23,18 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import br.alexandregpereira.hunter.shareContent.state.ShareContentExportState
 import br.alexandregpereira.hunter.shareContent.state.ShareContentExtractedState
 import br.alexandregpereira.hunter.ui.compose.AppButton
 import br.alexandregpereira.hunter.ui.compose.BottomSheet
-import br.alexandregpereira.hunter.ui.compose.EmptyScreenMessageContent
 import br.alexandregpereira.hunter.ui.compose.LoadingScreen
 import br.alexandregpereira.hunter.ui.compose.LoadingScreenState
 import br.alexandregpereira.hunter.ui.compose.ScreenHeader
@@ -95,7 +97,11 @@ internal fun ShareContentExportScreen(
         state = loadingState,
         fillMaxSize = false,
         errorContent = {
-            EmptyScreenMessageContent(title = exportStrings.exportErrorTitle)
+            Text(
+                text = exportStrings.exportErrorTitle,
+                fontWeight = FontWeight.SemiBold,
+                fontSize = 16.sp,
+            )
         }
     ) { extractedState ->
         Column(

--- a/feature/share-content/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/shareContent/ui/ShareContentImportScreen.kt
+++ b/feature/share-content/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/shareContent/ui/ShareContentImportScreen.kt
@@ -17,27 +17,31 @@
 
 package br.alexandregpereira.hunter.shareContent.ui
 
-import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.AndroidUiModes.UI_MODE_NIGHT_YES
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import br.alexandregpereira.hunter.shareContent.state.ShareContentExtractedState
+import br.alexandregpereira.hunter.shareContent.state.ShareContentImportError
 import br.alexandregpereira.hunter.shareContent.state.ShareContentImportState
 import br.alexandregpereira.hunter.ui.compose.AppButton
 import br.alexandregpereira.hunter.ui.compose.BottomSheet
 import br.alexandregpereira.hunter.ui.compose.LoadingScreen
+import br.alexandregpereira.hunter.ui.compose.PreviewWindow
 import br.alexandregpereira.hunter.ui.compose.ScreenHeader
 
 @Composable
 internal fun ShareContentImportBottomSheet(
-    isOpen: Boolean,
     state: ShareContentImportState,
     onImport: () -> Unit,
     onFilePickClick: () -> Unit,
@@ -49,13 +53,14 @@ internal fun ShareContentImportBottomSheet(
         bottom = 16.dp,
     ),
     topSpaceHeight = 0.dp,
-    opened = isOpen,
+    opened = state.isOpen,
     onClose = onClose,
-    modifier = Modifier.animateContentSize()
 ) {
     CompositionLocalProvider(LocalImportStrings provides state.strings) {
         ShareContentImportScreen(
-            state = state,
+            isLoading = state.isLoading,
+            extractedState = state.importExtractedState,
+            importErrorMessage = state.importErrorMessage,
             onImport = onImport,
             onFilePickClick = onFilePickClick,
         )
@@ -64,24 +69,26 @@ internal fun ShareContentImportBottomSheet(
 
 @Composable
 internal fun ShareContentImportScreen(
-    state: ShareContentImportState,
+    isLoading: Boolean,
+    extractedState: ShareContentExtractedState?,
+    importErrorMessage: String?,
     onImport: () -> Unit,
     onFilePickClick: () -> Unit,
 ) = Column {
     Spacer(modifier = Modifier.height(16.dp))
 
-    ScreenHeader(title = state.strings.importTitle)
+    ScreenHeader(title = importStrings.importTitle)
 
     Spacer(modifier = Modifier.height(16.dp))
 
     LoadingScreen(
-        isLoading = state.isLoading,
+        isLoading = isLoading,
         fillMaxSize = false,
     ) {
         Column {
-            if (state.importExtractedState != null) {
+            if (extractedState != null) {
                 ShareContentExtracted(
-                    state = state.importExtractedState,
+                    state = extractedState,
                     strings = importStrings.extractedStrings,
                 )
 
@@ -93,10 +100,10 @@ internal fun ShareContentImportScreen(
                 )
             } else {
                 ShareContentImportFilePickerScreen(
-                    importErrorMessage = state.importErrorMessage,
+                    importErrorMessage = importErrorMessage,
                 )
 
-                Spacer(modifier = Modifier.height(32.dp))
+                Spacer(modifier = Modifier.height(24.dp))
 
                 AppButton(
                     text = importStrings.pickCompendiumFile,
@@ -111,12 +118,45 @@ internal fun ShareContentImportScreen(
 private fun ShareContentImportFilePickerScreen(
     importErrorMessage: String?,
 ) = Column {
+    Spacer(modifier = Modifier.height(8.dp))
     importErrorMessage?.takeIf { it.isNotBlank() }?.let { errorMessage ->
-        Spacer(modifier = Modifier.height(16.dp))
         Text(
             text = errorMessage,
             fontWeight = FontWeight.SemiBold,
             fontSize = 16.sp,
         )
-    }
+    } ?: Text(
+        text = importStrings.pickCompendiumFileDescription,
+        fontWeight = FontWeight.Normal,
+        color = MaterialTheme.colors.onSurface.copy(alpha = .7f),
+        fontSize = 16.sp,
+    )
+    Spacer(modifier = Modifier.height(8.dp))
+}
+
+@Preview(uiMode = UI_MODE_NIGHT_YES)
+@Composable
+private fun ShareContentImportBottomSheetPreview() = PreviewWindow {
+    ShareContentImportBottomSheet(
+        state = ShareContentImportState(
+            isOpen = true,
+        ),
+        onImport = {},
+        onClose = {},
+        onFilePickClick = {},
+    )
+}
+
+@Preview(uiMode = UI_MODE_NIGHT_YES)
+@Composable
+private fun ShareContentImportBottomSheetInvalidPreview() = PreviewWindow {
+    ShareContentImportBottomSheet(
+        state = ShareContentImportState(
+            isOpen = true,
+            importError = ShareContentImportError.InvalidContent,
+        ),
+        onImport = {},
+        onClose = {},
+        onFilePickClick = {},
+    )
 }

--- a/ui/core/src/commonMain/kotlin/br/alexandregpereira/hunter/ui/compose/Animation.kt
+++ b/ui/core/src/commonMain/kotlin/br/alexandregpereira/hunter/ui/compose/Animation.kt
@@ -17,60 +17,108 @@
 
 package br.alexandregpereira.hunter.ui.compose
 
-import androidx.compose.animation.core.AnimationSpec
-import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.Spring
 import androidx.compose.animation.core.spring
+import androidx.compose.foundation.IndicationNodeFactory
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.interaction.InteractionSource
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.interaction.collectIsPressedAsState
-import androidx.compose.runtime.getValue
+import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
-import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.drawscope.ContentDrawScope
+import androidx.compose.ui.graphics.drawscope.scale
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.node.DelegatableNode
+import androidx.compose.ui.node.DrawModifierNode
 import androidx.compose.ui.platform.LocalHapticFeedback
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
 
 fun Modifier.animatePressed(
-    pressedScale: Float = 0.96f,
+    pressedScale: Float = 0.9f,
     enabled: Boolean = true,
     onClick: () -> Unit = {},
     onLongClick: (() -> Unit)? = null,
 ): Modifier = composed {
-    val interactionSource = remember { MutableInteractionSource() }
     val haptic = LocalHapticFeedback.current
-
-    animatePressed(
-        interactionSource = interactionSource,
-        pressedScale = pressedScale
-    ).combinedClickable(
-        interactionSource = interactionSource,
-        indication = null,
+    val onLongClickFinal: (() -> Unit)? = if (onLongClick == null) null else ({
+        haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+        onLongClick.invoke()
+    })
+    combinedClickable(
+        interactionSource = remember { MutableInteractionSource() },
+        indication = ScaleIndication(pressedScale),
         enabled = enabled,
         onClick = onClick,
-        onLongClick = {
-            onLongClick?.run {
-                haptic.performHapticFeedback(HapticFeedbackType.LongPress)
-                invoke()
-            }
-        }
+        onLongClick = onLongClickFinal,
     )
 }
 
-fun Modifier.animatePressed(
-    interactionSource: InteractionSource,
-    pressedScale: Float = 0.96f
-): Modifier = composed {
-    val animationSpec: AnimationSpec<Float> = spring(stiffness = 600f)
-    val isPressed by interactionSource.collectIsPressedAsState()
-    val scale by animateFloatAsState(
-        targetValue = if (isPressed) pressedScale else 1f,
-        animationSpec = animationSpec
-    )
+class ScaleIndication(private val pressedScale: Float = 0.96f) : IndicationNodeFactory {
+    override fun create(interactionSource: InteractionSource): DelegatableNode =
+        ScaleIndicationNode(pressedScale, interactionSource)
 
-    this.graphicsLayer(
-        scaleX = scale,
-        scaleY = scale
-    )
+    override fun equals(other: Any?) =
+        other is ScaleIndication && other.pressedScale == pressedScale
+
+    override fun hashCode() = pressedScale.hashCode()
+}
+
+private class ScaleIndicationNode(
+    private val pressedScale: Float,
+    private val interactionSource: InteractionSource,
+) : Modifier.Node(), DrawModifierNode {
+
+    private val animatableScale = Animatable(1f)
+
+    override fun onAttach() {
+        coroutineScope.launch {
+            var animationJob: Job? = null
+            interactionSource.interactions.collect { interaction ->
+                when (interaction) {
+                    is PressInteraction.Press -> {
+                        animationJob?.cancel()
+                        animationJob = launch {
+                            animatableScale.animateTo(
+                                targetValue = pressedScale,
+                                animationSpec = spring(
+                                    stiffness = 600f,
+                                    dampingRatio = Spring.DampingRatioNoBouncy
+                                )
+                            )
+                        }
+                    }
+
+                    is PressInteraction.Release, is PressInteraction.Cancel -> {
+                        animationJob?.cancel()
+                        animationJob = launch {
+                            animatableScale.animateTo(
+                                targetValue = pressedScale,
+                                animationSpec = spring(
+                                    stiffness = 600f,
+                                    dampingRatio = Spring.DampingRatioNoBouncy
+                                )
+                            )
+                            animatableScale.animateTo(
+                                targetValue = 1f,
+                                animationSpec = spring(
+                                    stiffness = 400f,
+                                    dampingRatio = Spring.DampingRatioMediumBouncy
+                                )
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    override fun ContentDrawScope.draw() {
+        scale(animatableScale.value) {
+            this@draw.drawContent()
+        }
+    }
 }

--- a/ui/core/src/commonMain/kotlin/br/alexandregpereira/hunter/ui/compose/CircleImage.kt
+++ b/ui/core/src/commonMain/kotlin/br/alexandregpereira/hunter/ui/compose/CircleImage.kt
@@ -34,7 +34,7 @@ fun CircleImage(
     modifier: Modifier = Modifier,
     size: Dp = 48.dp,
     onClick: () -> Unit = {},
-    onLongClick: () -> Unit = {},
+    onLongClick: (() -> Unit)? = null,
 ) {
     MonsterCoilImage(
         imageUrl = imageUrl,

--- a/ui/core/src/commonMain/kotlin/br/alexandregpereira/hunter/ui/compose/Closeable.kt
+++ b/ui/core/src/commonMain/kotlin/br/alexandregpereira/hunter/ui/compose/Closeable.kt
@@ -18,6 +18,7 @@
 package br.alexandregpereira.hunter.ui.compose
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.background
@@ -42,7 +43,9 @@ fun Closeable(
         modifier = modifier,
         visible = isOpen,
         enter = fadeIn(),
-        exit = fadeOut(),
+        exit = fadeOut(
+            animationSpec = tween(durationMillis = 50),
+        ),
     ) {
         val offset = getScrollOffset().absoluteValue
         val fraction = offset.coerceAtMost(300) / 300f

--- a/ui/core/src/commonMain/kotlin/br/alexandregpereira/hunter/ui/compose/MildBounceOverscrollFactory.kt
+++ b/ui/core/src/commonMain/kotlin/br/alexandregpereira/hunter/ui/compose/MildBounceOverscrollFactory.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.unit.Velocity
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.supervisorScope
 
 internal class MildBounceOverscrollFactory : OverscrollFactory {
     override fun createOverscrollEffect(): OverscrollEffect = MildBounceOverscrollEffect()
@@ -45,10 +46,14 @@ internal class MildBounceOverscrollFactory : OverscrollFactory {
 private class MildBounceOverscrollEffect : OverscrollEffect {
     private var offsetY by mutableStateOf(0f)
     private var bounceJob: Job? = null
+    private var activeFlingJob: Job? = null
     private var edgeHitHandled = false
     private var nodeScope: CoroutineScope? = null
+    private var isSpringAnimating = false
 
-    override val isInProgress: Boolean get() = offsetY != 0f
+    // False during spring-back so pointer events are not intercepted by the
+    // scrollable while the visual bounce animation plays.
+    override val isInProgress: Boolean get() = offsetY != 0f && !isSpringAnimating
 
     override fun applyToScroll(
         delta: Offset,
@@ -68,13 +73,16 @@ private class MildBounceOverscrollEffect : OverscrollEffect {
             }
             // SideEffect is the source during a fling animation. When performScroll doesn't
             // consume all the delta the fling has hit an edge. Start the spring immediately
-            // here rather than waiting for performFling to return (which on iOS can take ~1s).
+            // here rather than waiting for performFling to return (which on iOS can take ~1s),
+            // and cancel the fling so the gesture coroutine is freed immediately — otherwise
+            // it stays blocked on performFling and swallows the first tap after the bounce.
             source == NestedScrollSource.SideEffect && overscrollY != 0f && !edgeHitHandled -> {
                 edgeHitHandled = true
                 val startOffset = offsetY + overscrollY * Resistance
                 offsetY = startOffset
                 bounceJob?.cancel()
                 bounceJob = nodeScope?.launch { springBackToZero(startOffset) }
+                activeFlingJob?.cancel()
             }
         }
         return delta
@@ -88,7 +96,15 @@ private class MildBounceOverscrollEffect : OverscrollEffect {
         // fling could reset edgeHitHandled while SideEffect callbacks from the first are live.
         bounceJob?.cancel()
         edgeHitHandled = false
-        performFling(velocity)
+        // Run performFling as a cancellable child job so applyToScroll can cancel it the moment
+        // the edge is hit and the spring starts. supervisorScope prevents the child cancellation
+        // from propagating to the outer gesture coroutine.
+        supervisorScope {
+            val flingCoroutine = launch { performFling(velocity) }
+            activeFlingJob = flingCoroutine
+            flingCoroutine.join()
+            activeFlingJob = null
+        }
         // Edge spring is already handled in applyToScroll(SideEffect). Only spring back here
         // for drag-based overscroll (UserInput) that wasn't followed by an edge-hitting fling.
         if (!edgeHitHandled && offsetY != 0f) {
@@ -97,8 +113,14 @@ private class MildBounceOverscrollEffect : OverscrollEffect {
     }
 
     private suspend fun springBackToZero(from: Float) {
-        Animatable(from).animateTo(0f, SpringSpec) {
-            offsetY = value
+        isSpringAnimating = true
+        try {
+            Animatable(from).animateTo(0f, SpringSpec) {
+                offsetY = value
+            }
+        } finally {
+            isSpringAnimating = false
+            offsetY = 0f
         }
     }
 

--- a/ui/core/src/commonMain/kotlin/br/alexandregpereira/hunter/ui/compose/MonsterCard.kt
+++ b/ui/core/src/commonMain/kotlin/br/alexandregpereira/hunter/ui/compose/MonsterCard.kt
@@ -51,7 +51,7 @@ fun MonsterCard(
     isHorizontal: Boolean = false,
     modifier: Modifier = Modifier,
     onCLick: () -> Unit = {},
-    onLongCLick: () -> Unit = {},
+    onLongCLick: (() -> Unit)? = null,
 ) = ImageCard(
     name = name,
     isHorizontal = isHorizontal,
@@ -75,7 +75,7 @@ fun ImageCard(
     modifier: Modifier = Modifier,
     fontSize: TextUnit = 18.sp,
     onCLick: () -> Unit = {},
-    onLongCLick: () -> Unit = {},
+    onLongCLick: (() -> Unit)? = null,
     content: @Composable () -> Unit,
 ) {
     val shape = imageCardShape

--- a/ui/core/src/commonMain/kotlin/br/alexandregpereira/hunter/ui/compose/SpellIconInfo.kt
+++ b/ui/core/src/commonMain/kotlin/br/alexandregpereira/hunter/ui/compose/SpellIconInfo.kt
@@ -41,7 +41,7 @@ fun SpellIconInfo(
     name: String? = null,
     size: SpellIconSize = SpellIconSize.SMALL,
     onClick: () -> Unit = {},
-    onLongClick: () -> Unit = {},
+    onLongClick: (() -> Unit)? = null,
 ) {
     val iconColor = if (isSystemInDarkTheme()) school.iconColorDark else school.iconColorLight
     IconInfo(

--- a/ui/monster-compendium/src/commonMain/kotlin/br/alexandregpereira/hunter/ui/compendium/monster/MonterCompendium.kt
+++ b/ui/monster-compendium/src/commonMain/kotlin/br/alexandregpereira/hunter/ui/compendium/monster/MonterCompendium.kt
@@ -44,7 +44,7 @@ fun MonsterCompendium(
     listState: LazyGridState = rememberLazyGridState(),
     contentPadding: PaddingValues = PaddingValues(0.dp),
     onItemCLick: (index: String) -> Unit = {},
-    onItemLongCLick: (index: String) -> Unit = {},
+    onItemLongCLick: ((index: String) -> Unit)? = null,
 ) {
     val screenSizes = LocalScreenSize.current
     val currentWidth = screenSizes.widthInDp
@@ -71,6 +71,9 @@ fun MonsterCompendium(
         },
         cardContent = { item ->
             val monsterCardState = item.getMonsterCardState()
+            val onLongClick: (() -> Unit)? = if (onItemLongCLick != null) {
+                { onItemLongCLick(monsterCardState.index) }
+            } else null
             MonsterCard(
                 name = monsterCardState.name,
                 url = monsterCardState.imageState.url,
@@ -82,7 +85,7 @@ fun MonsterCompendium(
                 challengeRating = monsterCardState.imageState.challengeRating,
                 contentScale = monsterCardState.imageState.contentScale,
                 onCLick = { onItemCLick(monsterCardState.index) },
-                onLongCLick = { onItemLongCLick(monsterCardState.index) }
+                onLongCLick = onLongClick,
             )
         }
     )


### PR DESCRIPTION
*   **Refactor Animation System**:
    - Replace the `graphicsLayer`-based `animatePressed` with a more robust `ScaleIndication` using `IndicationNodeFactory`.
    - Implement a two-stage spring animation (stiffness: 600/400) for a more natural "bounce" effect on press release.
    - Add haptic feedback support for long-press events within `animatePressed`.
    - Fix overscroll behavior in `MildBounceOverscrollFactory` by ensuring fling animations are cancelled when hitting edges and preventing pointer interception during spring-back.

*   **Enhance Share Content Feature**:
    - Add descriptive text to the import screen to guide users on `.compendium` files.
    - Improve loading state management during file picking and extraction.
    - Update `CompendiumFileManager` to filter out empty image files during export preparation.
    - Refactor `ShareContentImportBottomSheet` and its screen to use state-driven visibility and more consistent error UI.
    - Fix a bug where `exportError` state wasn't reset when opening the export dialog.

*   **Update UI Components**:
    - Refactor `MonsterCard`, `CircleImage`, and `SpellIconInfo` to support optional `onLongClick` listeners.
    - Adjust `DifficultyClass` sizing (icon from 56dp to 48dp, font from 32sp to 28sp) and alignment.
    - Fine-tune `pressedScale` values for `ConditionBlock` (0.85f) and `LoreBlock` (0.95f) for better visual feedback.
    - Add a fast fade-out animation (50ms) to the `Closeable` background overlay.
    - Replace `EmptyScreenMessageContent` with a simpler `Text` component for export errors.

*   **Documentation & Localization**:
    - Add new localized strings for "Pick compendium file description" in English, Portuguese, and Spanish.