### PR TITLE
Integrate Google Ads SDK and User Messaging Platform (UMP) for iOS

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -113,6 +113,13 @@ tasks.register<UpdateIosVersionTask>("updateIosVersion") {
     versionName.set(appVersionName)
     versionCode.set(appVersionCode)
     iosAppDir.set(rootProject.layout.projectDirectory.dir("iosApp"))
+    admobAppId.set(
+        getEnvVar(
+            prodKey = "ADMOB_IOS_APP_ID",
+            sandboxKey = "ADMOB_SANDBOX_IOS_APP_ID",
+            fallback = "ca-app-pub-3940256099942544~3347511713",
+        )
+    )
 }
 
 tasks.matching { it.name.contains("embedAndSignAppleFrameworkForXcode") }

--- a/app/src/iosMain/kotlin/br/alexandregpereira/hunter/app/IosAppModule.kt
+++ b/app/src/iosMain/kotlin/br/alexandregpereira/hunter/app/IosAppModule.kt
@@ -17,6 +17,7 @@
 
 package br.alexandregpereira.hunter.app
 
+import br.alexandregpereira.hunter.ads.consent.AdsConsentManager
 import br.alexandregpereira.hunter.app.di.initKoinModules
 import br.alexandregpereira.hunter.featureFlag.FeatureFlagProvider
 import org.koin.core.Koin
@@ -31,4 +32,5 @@ fun initKoin() {
         initKoinModules()
     }.koin
     koinInstance.get<FeatureFlagProvider>().initialize()
+    koinInstance.get<AdsConsentManager>().initialize()
 }

--- a/buildSrc/src/main/kotlin/UpdateIosVersionTask.kt
+++ b/buildSrc/src/main/kotlin/UpdateIosVersionTask.kt
@@ -13,11 +13,14 @@ abstract class UpdateIosVersionTask : DefaultTask() {
     @get:Input
     abstract val versionCode: Property<Int>
 
+    @get:Input
+    abstract val admobAppId: Property<String>
+
     @get:OutputDirectory
     abstract val iosAppDir: DirectoryProperty
 
     init {
-        description = "Updates MARKETING_VERSION and CURRENT_PROJECT_VERSION in the CocoaPods xcconfig files."
+        description = "Updates MARKETING_VERSION, CURRENT_PROJECT_VERSION and GAD_APPLICATION_IDENTIFIER in the CocoaPods xcconfig files."
         group = "build"
     }
 
@@ -29,10 +32,15 @@ abstract class UpdateIosVersionTask : DefaultTask() {
 
         podsXcconfigDir.listFiles { f -> f.extension == "xcconfig" }?.forEach { xcconfig ->
             val lines = xcconfig.readLines()
-                .filter { !it.startsWith("MARKETING_VERSION") && !it.startsWith("CURRENT_PROJECT_VERSION") }
+                .filter {
+                    !it.startsWith("MARKETING_VERSION")
+                        && !it.startsWith("CURRENT_PROJECT_VERSION")
+                        && !it.startsWith("GAD_APPLICATION_IDENTIFIER")
+                }
             val updated = (lines + listOf(
                 "MARKETING_VERSION = ${versionName.get()}",
                 "CURRENT_PROJECT_VERSION = ${versionCode.get()}",
+                "GAD_APPLICATION_IDENTIFIER = ${admobAppId.get()}",
             )).joinToString("\n")
             xcconfig.writeText(updated)
         }

--- a/core/ads-consent/ads_consent.podspec
+++ b/core/ads-consent/ads_consent.podspec
@@ -1,0 +1,47 @@
+Pod::Spec.new do |spec|
+    spec.name                     = 'ads_consent'
+    spec.version                  = '1.0'
+    spec.homepage                 = 'https://github.com/alexandregpereira/monster-compendium'
+    spec.source                   = { :http=> ''}
+    spec.authors                  = ''
+    spec.license                  = ''
+    spec.summary                  = 'Ads consent module'
+    spec.vendored_frameworks      = 'build/cocoapods/framework/ads_consent.framework'
+    spec.libraries                = 'c++'
+    spec.ios.deployment_target    = '14.0'
+    spec.dependency 'Google-Mobile-Ads-SDK'
+    spec.dependency 'GoogleUserMessagingPlatform'
+    if !Dir.exist?('build/cocoapods/framework/ads_consent.framework') || Dir.empty?('build/cocoapods/framework/ads_consent.framework')
+        raise "
+        Kotlin framework 'ads_consent' doesn't exist yet, so a proper Xcode project can't be generated.
+        'pod install' should be executed after running ':generateDummyFramework' Gradle task:
+            ./gradlew :core:ads-consent:generateDummyFramework
+        Alternatively, proper pod installation is performed during Gradle sync in the IDE (if Podfile location is set)"
+    end
+    spec.xcconfig = {
+        'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO',
+    }
+    spec.pod_target_xcconfig = {
+        'KOTLIN_PROJECT_PATH' => ':core:ads-consent',
+        'PRODUCT_MODULE_NAME' => 'ads_consent',
+    }
+    spec.script_phases = [
+        {
+            :name => 'Build ads_consent',
+            :execution_position => :before_compile,
+            :shell_path => '/bin/sh',
+            :script => <<-SCRIPT
+                if [ "YES" = "$OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED" ]; then
+                    echo "Skipping Gradle build task invocation due to OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED environment variable set to \"YES\""
+                    exit 0
+                fi
+                set -ev
+                REPO_ROOT="$PODS_TARGET_SRCROOT"
+                "$REPO_ROOT/../../gradlew" -p "$REPO_ROOT" $KOTLIN_PROJECT_PATH:syncFramework \
+                    -Pkotlin.native.cocoapods.platform=$PLATFORM_NAME \
+                    -Pkotlin.native.cocoapods.archs="$ARCHS" \
+                    -Pkotlin.native.cocoapods.configuration="$CONFIGURATION"
+            SCRIPT
+        }
+    ]
+end

--- a/core/ads-consent/build.gradle.kts
+++ b/core/ads-consent/build.gradle.kts
@@ -18,6 +18,7 @@
 plugins {
     kotlin("multiplatform")
     id("com.android.library")
+    kotlin("native.cocoapods")
 }
 
 multiplatform {
@@ -32,6 +33,21 @@ multiplatform {
     }
     jvmMain()
     iosMain()
+}
+
+kotlin {
+    cocoapods {
+        version = "1.0"
+        summary = "Ads consent module"
+        homepage = "https://github.com/alexandregpereira/monster-compendium"
+        ios.deploymentTarget = "14.0"
+        pod("GoogleUserMessagingPlatform") {
+            moduleName = "UserMessagingPlatform"
+        }
+        pod("Google-Mobile-Ads-SDK") {
+            moduleName = "GoogleMobileAds"
+        }
+    }
 }
 
 android {

--- a/core/ads-consent/src/androidMain/kotlin/br/alexandregpereira/hunter/ads/consent/AndroidAdsConsentManager.kt
+++ b/core/ads-consent/src/androidMain/kotlin/br/alexandregpereira/hunter/ads/consent/AndroidAdsConsentManager.kt
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2026 Alexandre Gomes Pereira
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package br.alexandregpereira.hunter.ads.consent
 
 import android.annotation.SuppressLint

--- a/core/ads-consent/src/androidMain/kotlin/br/alexandregpereira/hunter/ads/consent/di/AdsConsentCoreModule.android.kt
+++ b/core/ads-consent/src/androidMain/kotlin/br/alexandregpereira/hunter/ads/consent/di/AdsConsentCoreModule.android.kt
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2026 Alexandre Gomes Pereira
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package br.alexandregpereira.hunter.ads.consent.di
 
 import android.app.Application

--- a/core/ads-consent/src/iosMain/kotlin/br/alexandregpereira/hunter/ads/consent/IosAdsConsentManager.kt
+++ b/core/ads-consent/src/iosMain/kotlin/br/alexandregpereira/hunter/ads/consent/IosAdsConsentManager.kt
@@ -1,0 +1,73 @@
+package br.alexandregpereira.hunter.ads.consent
+
+import br.alexandregpereira.hunter.analytics.Analytics
+import cocoapods.GoogleUserMessagingPlatform.UMPConsentForm
+import cocoapods.GoogleUserMessagingPlatform.UMPConsentInformation
+import cocoapods.GoogleUserMessagingPlatform.UMPDebugGeographyEEA
+import cocoapods.GoogleUserMessagingPlatform.UMPDebugSettings
+import cocoapods.GoogleUserMessagingPlatform.UMPRequestParameters
+import cocoapods.Google_Mobile_Ads_SDK.GADMobileAds
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import platform.Foundation.NSError
+import platform.UIKit.UIApplication
+
+@OptIn(ExperimentalForeignApi::class)
+internal class IosAdsConsentManager(
+    private val analytics: Analytics,
+    private val debugHashedId: String? = null,
+) : AdsConsentManager {
+
+    private val consentInformation = UMPConsentInformation.sharedInstance
+
+    private val _canRequestAds = MutableStateFlow(consentInformation.canRequestAds)
+    override val canRequestAds: StateFlow<Boolean> = _canRequestAds.asStateFlow()
+
+    override fun initialize() {
+        GADMobileAds.sharedInstance().startWithCompletionHandler(null)
+    }
+
+    override fun showConsentFormIfRequired() {
+        requestConsent(shouldShowConsentForm = true)
+    }
+
+    override fun loadConsentInfo() {
+        requestConsent(shouldShowConsentForm = false)
+    }
+
+    private fun requestConsent(shouldShowConsentForm: Boolean) {
+        val rootViewController = UIApplication.sharedApplication.keyWindow?.rootViewController
+        if (rootViewController == null) {
+            analytics.logException(
+                IllegalStateException("Failed to check ads consent. rootViewController is null.")
+            )
+            return
+        }
+
+        val params = UMPRequestParameters()
+        debugHashedId?.let { hashedId ->
+            val debugSettings = UMPDebugSettings()
+            debugSettings.testDeviceIdentifiers = listOf(hashedId)
+            debugSettings.geography = UMPDebugGeographyEEA
+            params.debugSettings = debugSettings
+        }
+        consentInformation.requestConsentInfoUpdateWithParameters(params) { error: NSError? ->
+            if (error != null) {
+                analytics.logException(Exception(error.localizedDescription))
+                _canRequestAds.value = consentInformation.canRequestAds
+                return@requestConsentInfoUpdateWithParameters
+            }
+            if (shouldShowConsentForm) {
+                UMPConsentForm.loadAndPresentIfRequiredFromViewController(
+                    rootViewController
+                ) { _: NSError? ->
+                    _canRequestAds.value = consentInformation.canRequestAds
+                }
+            } else {
+                _canRequestAds.value = consentInformation.canRequestAds
+            }
+        }
+    }
+}

--- a/core/ads-consent/src/iosMain/kotlin/br/alexandregpereira/hunter/ads/consent/IosAdsConsentManager.kt
+++ b/core/ads-consent/src/iosMain/kotlin/br/alexandregpereira/hunter/ads/consent/IosAdsConsentManager.kt
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2026 Alexandre Gomes Pereira
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package br.alexandregpereira.hunter.ads.consent
 
 import br.alexandregpereira.hunter.analytics.Analytics
@@ -11,8 +28,12 @@ import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import platform.AppTrackingTransparency.ATTrackingManager
+import platform.AppTrackingTransparency.ATTrackingManagerAuthorizationStatusNotDetermined
 import platform.Foundation.NSError
 import platform.UIKit.UIApplication
+import platform.UIKit.UISceneActivationStateForegroundActive
+import platform.UIKit.UIWindowScene
 
 @OptIn(ExperimentalForeignApi::class)
 internal class IosAdsConsentManager(
@@ -22,7 +43,7 @@ internal class IosAdsConsentManager(
 
     private val consentInformation = UMPConsentInformation.sharedInstance
 
-    private val _canRequestAds = MutableStateFlow(consentInformation.canRequestAds)
+    private val _canRequestAds = MutableStateFlow(false)
     override val canRequestAds: StateFlow<Boolean> = _canRequestAds.asStateFlow()
 
     override fun initialize() {
@@ -38,7 +59,10 @@ internal class IosAdsConsentManager(
     }
 
     private fun requestConsent(shouldShowConsentForm: Boolean) {
-        val rootViewController = UIApplication.sharedApplication.keyWindow?.rootViewController
+        val scene = UIApplication.sharedApplication.connectedScenes
+            .filterIsInstance<UIWindowScene>()
+            .firstOrNull { it.activationState == UISceneActivationStateForegroundActive }
+        val rootViewController = scene?.keyWindow?.rootViewController
         if (rootViewController == null) {
             analytics.logException(
                 IllegalStateException("Failed to check ads consent. rootViewController is null.")
@@ -56,18 +80,30 @@ internal class IosAdsConsentManager(
         consentInformation.requestConsentInfoUpdateWithParameters(params) { error: NSError? ->
             if (error != null) {
                 analytics.logException(Exception(error.localizedDescription))
-                _canRequestAds.value = consentInformation.canRequestAds
+                if (shouldShowConsentForm) {
+                    _canRequestAds.value = consentInformation.canRequestAds
+                }
                 return@requestConsentInfoUpdateWithParameters
             }
             if (shouldShowConsentForm) {
                 UMPConsentForm.loadAndPresentIfRequiredFromViewController(
                     rootViewController
                 ) { _: NSError? ->
-                    _canRequestAds.value = consentInformation.canRequestAds
+                    requestAttIfNeeded()
                 }
-            } else {
+            }
+        }
+    }
+
+    private fun requestAttIfNeeded() {
+        if (ATTrackingManager.trackingAuthorizationStatus ==
+            ATTrackingManagerAuthorizationStatusNotDetermined
+        ) {
+            ATTrackingManager.requestTrackingAuthorizationWithCompletionHandler { _ ->
                 _canRequestAds.value = consentInformation.canRequestAds
             }
+        } else {
+            _canRequestAds.value = consentInformation.canRequestAds
         }
     }
 }

--- a/core/ads-consent/src/iosMain/kotlin/br/alexandregpereira/hunter/ads/consent/di/AdsConsentCoreModule.ios.kt
+++ b/core/ads-consent/src/iosMain/kotlin/br/alexandregpereira/hunter/ads/consent/di/AdsConsentCoreModule.ios.kt
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2026 Alexandre Gomes Pereira
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package br.alexandregpereira.hunter.ads.consent.di
 
 import br.alexandregpereira.hunter.ads.consent.AdsConsentManager

--- a/core/ads-consent/src/iosMain/kotlin/br/alexandregpereira/hunter/ads/consent/di/AdsConsentCoreModule.ios.kt
+++ b/core/ads-consent/src/iosMain/kotlin/br/alexandregpereira/hunter/ads/consent/di/AdsConsentCoreModule.ios.kt
@@ -1,11 +1,14 @@
 package br.alexandregpereira.hunter.ads.consent.di
 
 import br.alexandregpereira.hunter.ads.consent.AdsConsentManager
-import br.alexandregpereira.hunter.ads.consent.EmptyAdsConsentManager
+import br.alexandregpereira.hunter.ads.consent.IosAdsConsentManager
 import org.koin.core.scope.Scope
 
 internal actual fun Scope.createAdsConsentManager(
     deviceDebugHashTestId: String?
 ): AdsConsentManager {
-    return EmptyAdsConsentManager()
+    return IosAdsConsentManager(
+        analytics = get(),
+        debugHashedId = deviceDebugHashTestId,
+    )
 }

--- a/core/ads-consent/src/jvmMain/kotlin/br/alexandregpereira/hunter/ads/consent/di/AdsConsentCoreModule.jvm.kt
+++ b/core/ads-consent/src/jvmMain/kotlin/br/alexandregpereira/hunter/ads/consent/di/AdsConsentCoreModule.jvm.kt
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2026 Alexandre Gomes Pereira
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package br.alexandregpereira.hunter.ads.consent.di
 
 import br.alexandregpereira.hunter.ads.consent.AdsConsentManager

--- a/feature/ads/compose/ads_compose.podspec
+++ b/feature/ads/compose/ads_compose.podspec
@@ -1,0 +1,47 @@
+Pod::Spec.new do |spec|
+    spec.name                     = 'ads_compose'
+    spec.version                  = '1.0'
+    spec.homepage                 = 'https://github.com/alexandregpereira/monster-compendium'
+    spec.source                   = { :http=> ''}
+    spec.authors                  = ''
+    spec.license                  = ''
+    spec.summary                  = 'Ads compose feature'
+    spec.vendored_frameworks      = 'build/cocoapods/framework/compose.framework'
+    spec.libraries                = 'c++'
+    spec.ios.deployment_target    = '14.0'
+    spec.dependency 'Google-Mobile-Ads-SDK'
+    if !Dir.exist?('build/cocoapods/framework/compose.framework') || Dir.empty?('build/cocoapods/framework/compose.framework')
+        raise "
+        Kotlin framework 'compose' doesn't exist yet, so a proper Xcode project can't be generated.
+        'pod install' should be executed after running ':generateDummyFramework' Gradle task:
+            ./gradlew :feature:ads:compose:generateDummyFramework
+        Alternatively, proper pod installation is performed during Gradle sync in the IDE (if Podfile location is set)"
+    end
+    spec.xcconfig = {
+        'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO',
+    }
+    spec.pod_target_xcconfig = {
+        'KOTLIN_PROJECT_PATH' => ':feature:ads:compose',
+        'PRODUCT_MODULE_NAME' => 'compose',
+    }
+    spec.script_phases = [
+        {
+            :name => 'Build ads_compose',
+            :execution_position => :before_compile,
+            :shell_path => '/bin/sh',
+            :script => <<-SCRIPT
+                if [ "YES" = "$OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED" ]; then
+                    echo "Skipping Gradle build task invocation due to OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED environment variable set to \"YES\""
+                    exit 0
+                fi
+                set -ev
+                REPO_ROOT="$PODS_TARGET_SRCROOT"
+                "$REPO_ROOT/../../../gradlew" -p "$REPO_ROOT" $KOTLIN_PROJECT_PATH:syncFramework \
+                    -Pkotlin.native.cocoapods.platform=$PLATFORM_NAME \
+                    -Pkotlin.native.cocoapods.archs="$ARCHS" \
+                    -Pkotlin.native.cocoapods.configuration="$CONFIGURATION"
+            SCRIPT
+        }
+    ]
+    spec.resources = ['build/compose/cocoapods/compose-resources']
+end

--- a/feature/ads/compose/build.gradle.kts
+++ b/feature/ads/compose/build.gradle.kts
@@ -20,6 +20,7 @@ plugins {
     kotlin("multiplatform")
     alias(libs.plugins.compose)
     alias(libs.plugins.compose.compiler)
+    kotlin("native.cocoapods")
 }
 
 multiplatform {
@@ -41,6 +42,19 @@ multiplatform {
     }
     jvmMain()
     iosMain()
+}
+
+kotlin {
+    cocoapods {
+        name = "ads_compose"
+        version = "1.0"
+        summary = "Ads compose feature"
+        homepage = "https://github.com/alexandregpereira/monster-compendium"
+        ios.deploymentTarget = "14.0"
+        pod("Google-Mobile-Ads-SDK") {
+            moduleName = "GoogleMobileAds"
+        }
+    }
 }
 
 androidLibrary {

--- a/feature/ads/compose/src/iosMain/kotlin/br/alexandregpereira/hunter/ads/AdsBannerView.ios.kt
+++ b/feature/ads/compose/src/iosMain/kotlin/br/alexandregpereira/hunter/ads/AdsBannerView.ios.kt
@@ -1,8 +1,27 @@
+/*
+ * Copyright (C) 2026 Alexandre Gomes Pereira
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package br.alexandregpereira.hunter.ads
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.viewinterop.UIKitView
 import br.alexandregpereira.hunter.ads.consent.AdsConsentManager
 import cocoapods.Google_Mobile_Ads_SDK.GADBannerView
@@ -12,21 +31,28 @@ import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.useContents
 import org.koin.compose.koinInject
 import platform.UIKit.UIApplication
+import platform.UIKit.UISceneActivationStateForegroundActive
 import platform.UIKit.UIScreen
+import platform.UIKit.UIWindowScene
 
 @OptIn(ExperimentalForeignApi::class, kotlin.experimental.ExperimentalNativeApi::class)
 @Composable
 internal actual fun AdsBannerView() {
     val consentManager: AdsConsentManager = koinInject()
     val canRequestAds by consentManager.canRequestAds.collectAsState()
+    val adLoaded = remember { mutableStateOf(false) }
 
-    if (!canRequestAds) return
-
-    val rootViewController = UIApplication.sharedApplication.keyWindow?.rootViewController
-        ?: return
-
+    // UIKitView is always composed so factory runs at app startup when the scene is stable.
+    // loadRequest is deferred to update() to avoid a timing issue where the scene is briefly
+    // inactive during the UMP/ATT consent modal dismissal animation.
     UIKitView(
         factory = {
+            val scene = UIApplication.sharedApplication.connectedScenes
+                .filterIsInstance<UIWindowScene>()
+                .firstOrNull { it.activationState == UISceneActivationStateForegroundActive }
+            val rootViewController = scene?.keyWindow?.rootViewController
+                ?: return@UIKitView GADBannerView()
+
             val screenWidth = UIScreen.mainScreen.bounds.useContents { size.width }
             val adSize = GADLargeAnchoredAdaptiveBannerAdSizeWithWidth(screenWidth)
             GADBannerView(adSize).apply {
@@ -36,7 +62,12 @@ internal actual fun AdsBannerView() {
                     "ca-app-pub-9186388258407371/2524216431"
                 }
                 this.rootViewController = rootViewController
-                loadRequest(GADRequest.request())
+            }
+        },
+        update = { bannerView ->
+            if (canRequestAds && !adLoaded.value && bannerView.adUnitID != null) {
+                bannerView.loadRequest(GADRequest.request())
+                adLoaded.value = true
             }
         },
     )

--- a/feature/ads/compose/src/iosMain/kotlin/br/alexandregpereira/hunter/ads/AdsBannerView.ios.kt
+++ b/feature/ads/compose/src/iosMain/kotlin/br/alexandregpereira/hunter/ads/AdsBannerView.ios.kt
@@ -1,8 +1,43 @@
 package br.alexandregpereira.hunter.ads
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.viewinterop.UIKitView
+import br.alexandregpereira.hunter.ads.consent.AdsConsentManager
+import cocoapods.Google_Mobile_Ads_SDK.GADBannerView
+import cocoapods.Google_Mobile_Ads_SDK.GADLargeAnchoredAdaptiveBannerAdSizeWithWidth
+import cocoapods.Google_Mobile_Ads_SDK.GADRequest
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.useContents
+import org.koin.compose.koinInject
+import platform.UIKit.UIApplication
+import platform.UIKit.UIScreen
 
+@OptIn(ExperimentalForeignApi::class, kotlin.experimental.ExperimentalNativeApi::class)
 @Composable
 internal actual fun AdsBannerView() {
-    // No-op on iOS
+    val consentManager: AdsConsentManager = koinInject()
+    val canRequestAds by consentManager.canRequestAds.collectAsState()
+
+    if (!canRequestAds) return
+
+    val rootViewController = UIApplication.sharedApplication.keyWindow?.rootViewController
+        ?: return
+
+    UIKitView(
+        factory = {
+            val screenWidth = UIScreen.mainScreen.bounds.useContents { size.width }
+            val adSize = GADLargeAnchoredAdaptiveBannerAdSizeWithWidth(screenWidth)
+            GADBannerView(adSize).apply {
+                adUnitID = if (Platform.isDebugBinary) {
+                    "ca-app-pub-3940256099942544/2435281174"
+                } else {
+                    "ca-app-pub-9186388258407371/2524216431"
+                }
+                this.rootViewController = rootViewController
+                loadRequest(GADRequest.request())
+            }
+        },
+    )
 }

--- a/feature/paywall/compose/build.gradle.kts
+++ b/feature/paywall/compose/build.gradle.kts
@@ -24,6 +24,7 @@ plugins {
 multiplatform {
     androidMain()
     commonMain {
+        implementation(project(":core:ads-consent"))
         implementation(project(":core:analytics"))
         implementation(project(":core:event"))
         implementation(project(":core:localization"))

--- a/feature/paywall/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/paywall/PaywallFeature.kt
+++ b/feature/paywall/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/paywall/PaywallFeature.kt
@@ -2,17 +2,29 @@ package br.alexandregpereira.hunter.paywall
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.platform.LocalUriHandler
 import br.alexandregpereira.hunter.paywall.ui.LocalStrings
 import br.alexandregpereira.hunter.paywall.ui.PaywallScreen
 import br.alexandregpereira.hunter.ui.compose.LifecycleEventObserver
+import kotlinx.coroutines.flow.collectLatest
 import org.koin.compose.koinInject
 
 @Composable
 fun PaywallFeature() {
     val stateHolder = koinInject<PaywallStateHolder>()
     val state by stateHolder.state.collectAsState()
+
+    val uriHandler = LocalUriHandler.current
+    LaunchedEffect(stateHolder, uriHandler) {
+        stateHolder.action.collectLatest { action ->
+            when (action) {
+                is PaywallViewAction.GoToUrl -> uriHandler.openUri(action.url)
+            }
+        }
+    }
 
     LifecycleEventObserver(
         onStart = stateHolder::onStart,
@@ -28,6 +40,8 @@ fun PaywallFeature() {
             onTryAgainLoadOffer = stateHolder::onTryAgainLoadOffer,
             onTryAgainPurchase = stateHolder::onTryAgainPurchase,
             onComeBackToOffer = stateHolder::onComeBackToOffer,
+            onTerms = stateHolder::onTermsClick,
+            onPrivacy = stateHolder::onPrivacyClick,
         )
     }
 }

--- a/feature/paywall/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/paywall/PaywallFeature.kt
+++ b/feature/paywall/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/paywall/PaywallFeature.kt
@@ -28,7 +28,7 @@ fun PaywallFeature() {
 
     LifecycleEventObserver(
         onStart = stateHolder::onStart,
-        onResume = stateHolder::onStart,
+        onResume = stateHolder::onResume,
     )
 
     CompositionLocalProvider(LocalStrings provides state.strings) {

--- a/feature/paywall/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/paywall/PaywallStateHolder.kt
+++ b/feature/paywall/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/paywall/PaywallStateHolder.kt
@@ -56,6 +56,13 @@ internal class PaywallStateHolder(
         }
     }
 
+    fun onResume() {
+        if (state.value.isOpen) {
+            return
+        }
+        onStart()
+    }
+
     fun onClose() {
         closePaywall()
         loadOfferJob?.cancel()

--- a/feature/paywall/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/paywall/PaywallStateHolder.kt
+++ b/feature/paywall/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/paywall/PaywallStateHolder.kt
@@ -13,6 +13,7 @@ import br.alexandregpereira.hunter.revenue.IsPremium
 import br.alexandregpereira.hunter.revenue.OfferPeriod
 import br.alexandregpereira.hunter.revenue.Purchase
 import br.alexandregpereira.hunter.revenue.RestorePurchase
+import br.alexandregpereira.hunter.state.MutableActionHandler
 import br.alexandregpereira.hunter.state.UiModel
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
@@ -37,7 +38,8 @@ internal class PaywallStateHolder(
     private val appLocalization: AppLocalization,
     private val analytics: Analytics,
     private val dispatcher: CoroutineDispatcher = Dispatchers.Default,
-) : UiModel<PaywallState>(initialState = PaywallState()) {
+) : UiModel<PaywallState>(initialState = PaywallState()),
+    MutableActionHandler<PaywallViewAction> by MutableActionHandler() {
 
     private var loadOfferJob: Job? = null
     private var selectedOfferId: String = ""
@@ -120,6 +122,16 @@ internal class PaywallStateHolder(
     fun onComeBackToOffer() {
         analytics.track(eventName = "Paywall - come back to offer clicked")
         setState { copy(actionResultState = null) }
+    }
+
+    fun onTermsClick() {
+        analytics.track(eventName = "Paywall - terms clicked")
+        sendAction(PaywallViewAction.GoToUrl(state.value.strings.termsUrl))
+    }
+
+    fun onPrivacyClick() {
+        analytics.track(eventName = "Paywall - privacy clicked")
+        sendAction(PaywallViewAction.GoToUrl(state.value.strings.privacyUrl))
     }
 
     private fun loadOffer() {

--- a/feature/paywall/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/paywall/PaywallStrings.kt
+++ b/feature/paywall/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/paywall/PaywallStrings.kt
@@ -29,13 +29,17 @@ internal interface PaywallStrings {
     val subscriptionSuccessTitle: String
     val subscriptionSuccessDescription: String
     val buttonContinue: String
+    val termsButton: String
+    val privacyButton: String
+    val termsUrl: String
+    val privacyUrl: String
 }
 
 internal data class PaywallEnUsStrings(
     override val title: String = "Remove ads with Premium",
     override val description: String = "By subscribing to the premium plan, you remove ads and help maintain the project",
     override val subscribeButton: String = "Subscribe",
-    override val restoreButton: String = "Restore subscription",
+    override val restoreButton: String = "Restore",
     override val cancelAnytime: String = "Cancel anytime",
     override val featuresColumnHeader: String = "Features",
     override val freeColumnHeader: String = "Free",
@@ -57,13 +61,17 @@ internal data class PaywallEnUsStrings(
     override val subscriptionSuccessTitle: String = "You are a Premium member now!",
     override val subscriptionSuccessDescription: String = "Thank you for subscribing! You can now enjoy all the features of the app with no ads.",
     override val buttonContinue: String = "Continue",
+    override val termsButton: String = "Terms",
+    override val privacyButton: String = "Privacy",
+    override val termsUrl: String = "https://alexandregpereira.github.io/Monster-Compendium/docs/terms_of_use.html",
+    override val privacyUrl: String = "https://alexandregpereira.github.io/Monster-Compendium/docs/privacy_policy.html",
 ) : PaywallStrings
 
 internal data class PaywallPtBrStrings(
     override val title: String = "Remover anúncios com Premium",
     override val description: String = "Ao assinar o plano premium, você remove os anúncios e ajuda a manter o projeto",
     override val subscribeButton: String = "Assinar",
-    override val restoreButton: String = "Restaurar assinatura",
+    override val restoreButton: String = "Restaurar",
     override val cancelAnytime: String = "Cancele quando quiser",
     override val featuresColumnHeader: String = "Recursos",
     override val freeColumnHeader: String = "Grátis",
@@ -85,6 +93,10 @@ internal data class PaywallPtBrStrings(
     override val subscriptionSuccessTitle: String = "Você é um membro Premium agora!",
     override val subscriptionSuccessDescription: String = "Obrigado por assinar! Agora você pode aproveitar todos os recursos do aplicativo sem anúncios.",
     override val buttonContinue: String = "Continuar",
+    override val termsButton: String = "Termos",
+    override val privacyButton: String = "Privacidade",
+    override val termsUrl: String = "https://alexandregpereira.github.io/Monster-Compendium/docs/terms_of_use_pt_br.html",
+    override val privacyUrl: String = "https://alexandregpereira.github.io/Monster-Compendium/docs/privacy_policy_pt_br.html",
 ) : PaywallStrings
 
 internal fun PaywallStrings(): PaywallStrings = PaywallEnUsStrings()
@@ -93,7 +105,7 @@ internal data class PaywallEsStrings(
     override val title: String = "Eliminar anuncios con Premium",
     override val description: String = "Al suscribirte al plan premium, eliminas los anuncios y ayudas a mantener el proyecto",
     override val subscribeButton: String = "Suscribirse",
-    override val restoreButton: String = "Restaurar suscripción",
+    override val restoreButton: String = "Restaurar",
     override val cancelAnytime: String = "Cancela cuando quieras",
     override val featuresColumnHeader: String = "Características",
     override val freeColumnHeader: String = "Gratis",
@@ -115,6 +127,10 @@ internal data class PaywallEsStrings(
     override val subscriptionSuccessTitle: String = "¡Ahora eres miembro Premium!",
     override val subscriptionSuccessDescription: String = "¡Gracias por suscribirte! Ahora puedes disfrutar de todas las funciones de la aplicación sin anuncios.",
     override val buttonContinue: String = "Continuar",
+    override val termsButton: String = "Términos",
+    override val privacyButton: String = "Privacidad",
+    override val termsUrl: String = "https://alexandregpereira.github.io/Monster-Compendium/docs/terms_of_use_es.html",
+    override val privacyUrl: String = "https://alexandregpereira.github.io/Monster-Compendium/docs/privacy_policy_es.html",
 ) : PaywallStrings
 
 internal fun AppLocalization.getPaywallStrings(): PaywallStrings {

--- a/feature/paywall/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/paywall/PaywallViewAction.kt
+++ b/feature/paywall/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/paywall/PaywallViewAction.kt
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2026 Alexandre Gomes Pereira
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 package br.alexandregpereira.hunter.paywall
 
 internal sealed class PaywallViewAction {

--- a/feature/paywall/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/paywall/PaywallViewAction.kt
+++ b/feature/paywall/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/paywall/PaywallViewAction.kt
@@ -1,0 +1,5 @@
+package br.alexandregpereira.hunter.paywall
+
+internal sealed class PaywallViewAction {
+    data class GoToUrl(val url: String) : PaywallViewAction()
+}

--- a/feature/paywall/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/paywall/di/FeatureModule.kt
+++ b/feature/paywall/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/paywall/di/FeatureModule.kt
@@ -16,6 +16,7 @@ val paywallFeatureModule = module {
             getCurrentOffer = get(),
             settings = get(),
             analytics = get(),
+            adsConsentManager = get(),
         )
     }
     factory {

--- a/feature/paywall/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/paywall/domain/ShouldShowPaywall.kt
+++ b/feature/paywall/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/paywall/domain/ShouldShowPaywall.kt
@@ -1,9 +1,11 @@
 package br.alexandregpereira.hunter.paywall.domain
 
+import br.alexandregpereira.hunter.ads.consent.AdsConsentManager
 import br.alexandregpereira.hunter.analytics.Analytics
 import br.alexandregpereira.hunter.network.NetworkManager
 import br.alexandregpereira.hunter.revenue.GetCurrentOffer
 import br.alexandregpereira.hunter.revenue.IsSessionUsageLimitReached
+import kotlinx.coroutines.flow.firstOrNull
 
 internal class ShouldShowPaywall(
     private val isSessionUsageLimitReached: IsSessionUsageLimitReached,
@@ -11,12 +13,25 @@ internal class ShouldShowPaywall(
     private val getCurrentOffer: GetCurrentOffer,
     private val settings: PaywallSettings,
     private val analytics: Analytics,
+    private val adsConsentManager: AdsConsentManager,
 ) {
     suspend operator fun invoke(): Boolean {
         val paywallWasNotClosed = settings.getPaywallWasClosedFlag().not()
-        return paywallWasNotClosed && isSessionUsageLimitReached() &&
+        val shouldShow = paywallWasNotClosed && isSessionUsageLimitReached() &&
                 networkManager.isNetworkAvailable() &&
-                isCurrentOfferAvailable()
+                isCurrentOfferAvailable() &&
+                canRequestAds()
+        return shouldShow
+    }
+
+    private suspend fun canRequestAds(): Boolean {
+        if (adsConsentManager.canRequestAds.value) {
+            return true
+        }
+        val canRequestAds = adsConsentManager.canRequestAds.firstOrNull { canRequestAds ->
+            canRequestAds
+        }
+        return canRequestAds ?: false
     }
 
     private suspend fun isCurrentOfferAvailable(): Boolean {

--- a/feature/paywall/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/paywall/ui/PaywallComponents.kt
+++ b/feature/paywall/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/paywall/ui/PaywallComponents.kt
@@ -60,6 +60,8 @@ internal fun PaywallFooter(
     modifier: Modifier = Modifier,
     subscribe: () -> Unit,
     restore: () -> Unit,
+    onTerms: () -> Unit,
+    onPrivacy: () -> Unit,
 ) = Column(
     modifier = modifier,
     horizontalAlignment = Alignment.CenterHorizontally,
@@ -69,6 +71,8 @@ internal fun PaywallFooter(
     PaywallButtons(
         subscribe = subscribe,
         restore = restore,
+        onTerms = onTerms,
+        onPrivacy = onPrivacy,
     )
 }
 
@@ -76,6 +80,8 @@ internal fun PaywallFooter(
 internal fun PaywallButtons(
     subscribe: () -> Unit,
     restore: () -> Unit,
+    onTerms: () -> Unit,
+    onPrivacy: () -> Unit,
 ) = Column(
     verticalArrangement = Arrangement.spacedBy(8.dp),
 ) {
@@ -84,12 +90,29 @@ internal fun PaywallButtons(
         modifier = Modifier,
         onClick = subscribe,
     )
-    AppButton(
-        text = strings.restoreButton,
-        type = AppButtonType.TERTIARY,
-        size = AppButtonSize.SMALL,
-        onClick = restore,
-    )
+    Row {
+        AppButton(
+            modifier = Modifier.weight(1f),
+            text = strings.restoreButton,
+            type = AppButtonType.TERTIARY,
+            size = AppButtonSize.SMALL,
+            onClick = restore,
+        )
+        AppButton(
+            modifier = Modifier.weight(1f),
+            text = strings.termsButton,
+            type = AppButtonType.TERTIARY,
+            size = AppButtonSize.SMALL,
+            onClick = onTerms,
+        )
+        AppButton(
+            modifier = Modifier.weight(1f),
+            text = strings.privacyButton,
+            type = AppButtonType.TERTIARY,
+            size = AppButtonSize.SMALL,
+            onClick = onPrivacy,
+        )
+    }
 }
 
 @Composable

--- a/feature/paywall/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/paywall/ui/PaywallScreen.kt
+++ b/feature/paywall/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/paywall/ui/PaywallScreen.kt
@@ -38,6 +38,8 @@ internal fun PaywallScreen(
     onTryAgainLoadOffer: () -> Unit = {},
     onTryAgainPurchase: () -> Unit = {},
     onComeBackToOffer: () -> Unit = {},
+    onTerms: () -> Unit = {},
+    onPrivacy: () -> Unit = {},
 ) = AppScreen(
     isOpen = state.isOpen,
     swipeTriggerPercentage = 0.4f,
@@ -73,6 +75,8 @@ internal fun PaywallScreen(
                     subscriptionOfferFormatted = state.subscriptionOfferFormatted,
                     subscribe = subscribe,
                     restore = restore,
+                    onTerms = onTerms,
+                    onPrivacy = onPrivacy,
                 )
 
                 ScreenSizeType.LandscapeCompact,
@@ -81,6 +85,8 @@ internal fun PaywallScreen(
                     subscriptionOfferFormatted = state.subscriptionOfferFormatted,
                     subscribe = subscribe,
                     restore = restore,
+                    onTerms = onTerms,
+                    onPrivacy = onPrivacy,
                 )
             }
         }
@@ -94,6 +100,8 @@ internal fun PaywallScreenContent(
     modifier: Modifier = Modifier,
     subscribe: () -> Unit,
     restore: () -> Unit = {},
+    onTerms: () -> Unit = {},
+    onPrivacy: () -> Unit = {},
 ) {
     Column(
         modifier = modifier
@@ -111,6 +119,8 @@ internal fun PaywallScreenContent(
             subscriptionOfferFormatted = subscriptionOfferFormatted,
             subscribe = subscribe,
             restore = restore,
+            onTerms = onTerms,
+            onPrivacy = onPrivacy,
             modifier = Modifier.padding(bottom = 16.dp),
         )
     }
@@ -123,6 +133,8 @@ internal fun PaywallLandscapeScreenContent(
     modifier: Modifier = Modifier,
     subscribe: () -> Unit,
     restore: () -> Unit = {},
+    onTerms: () -> Unit = {},
+    onPrivacy: () -> Unit = {},
 ) {
     Row(
         modifier = modifier
@@ -139,6 +151,8 @@ internal fun PaywallLandscapeScreenContent(
             subscriptionOfferFormatted = subscriptionOfferFormatted,
             subscribe = subscribe,
             restore = restore,
+            onTerms = onTerms,
+            onPrivacy = onPrivacy,
         )
     }
 }

--- a/iosApp/MonsterCompendium.xcodeproj/project.pbxproj
+++ b/iosApp/MonsterCompendium.xcodeproj/project.pbxproj
@@ -142,6 +142,7 @@
 				C1BC0E7D29847A84002F517C /* Resources */,
 				681AC63E04636CC93F0717FB /* [CP] Embed Pods Frameworks */,
 				C193C3C12F8B08EE00E9D21E /* ShellScript */,
+				1B20CA1578FE33E289AE3EDD /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -260,6 +261,23 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		1B20CA1578FE33E289AE3EDD /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-MonsterCompendium/Pods-MonsterCompendium-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-MonsterCompendium/Pods-MonsterCompendium-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-MonsterCompendium/Pods-MonsterCompendium-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		681AC63E04636CC93F0717FB /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;

--- a/iosApp/MonsterCompendium/Info.plist
+++ b/iosApp/MonsterCompendium/Info.plist
@@ -46,5 +46,9 @@
 			</dict>
 		</dict>
 	</array>
+    <key>GADApplicationIdentifier</key>
+    <string>$(GAD_APPLICATION_IDENTIFIER)</string>
+    <key>NSUserTrackingUsageDescription</key>
+    <string>This identifier will be used to deliver personalized ads to you.</string>
 </dict>
 </plist>

--- a/iosApp/Podfile
+++ b/iosApp/Podfile
@@ -7,4 +7,6 @@ target 'MonsterCompendium' do
   pod 'FirebaseAnalytics'
   pod 'FirebaseCrashlytics'
   pod 'PurchasesHybridCommon', '17.55.1'
+  pod 'GoogleUserMessagingPlatform'
+  pod 'Google-Mobile-Ads-SDK'
 end

--- a/iosApp/Podfile.lock
+++ b/iosApp/Podfile.lock
@@ -57,6 +57,8 @@ PODS:
     - GoogleUtilities/UserDefaults (~> 8.1)
     - nanopb (~> 3.30910.0)
     - PromisesSwift (~> 2.1)
+  - Google-Mobile-Ads-SDK (13.2.0):
+    - GoogleUserMessagingPlatform (>= 1.1)
   - GoogleAdsOnDeviceConversion (2.1.0):
     - GoogleUtilities/Logger (~> 8.1)
     - GoogleUtilities/Network (~> 8.1)
@@ -86,6 +88,7 @@ PODS:
   - GoogleDataTransport (10.1.0):
     - nanopb (~> 3.30910.0)
     - PromisesObjC (~> 2.4)
+  - GoogleUserMessagingPlatform (3.1.0)
   - GoogleUtilities/AppDelegateSwizzler (8.1.0):
     - GoogleUtilities/Environment
     - GoogleUtilities/Logger
@@ -130,6 +133,8 @@ DEPENDENCIES:
   - AmplitudeSwift (~> 1.10)
   - FirebaseAnalytics
   - FirebaseCrashlytics
+  - Google-Mobile-Ads-SDK
+  - GoogleUserMessagingPlatform
   - PurchasesHybridCommon (= 17.55.1)
 
 SPEC REPOS:
@@ -146,9 +151,11 @@ SPEC REPOS:
     - FirebaseInstallations
     - FirebaseRemoteConfigInterop
     - FirebaseSessions
+    - Google-Mobile-Ads-SDK
     - GoogleAdsOnDeviceConversion
     - GoogleAppMeasurement
     - GoogleDataTransport
+    - GoogleUserMessagingPlatform
     - GoogleUtilities
     - nanopb
     - PromisesObjC
@@ -169,9 +176,11 @@ SPEC CHECKSUMS:
   FirebaseInstallations: 317270fec08a5d418fdbc8429282238cab3ac843
   FirebaseRemoteConfigInterop: 1c6135e8a094cc6368949f5faeeca7ee8948b8aa
   FirebaseSessions: b9a92c1c51bbb81e78fc3142cda6d925d700f8e7
+  Google-Mobile-Ads-SDK: f0365e190d66539c65cea8ded43e2c367abb5477
   GoogleAdsOnDeviceConversion: 2be6297a4f048459e0ae17fad9bfd2844e10cf64
   GoogleAppMeasurement: 700dce7541804bec33db590a5c496b663fbe2539
   GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
+  GoogleUserMessagingPlatform: befe603da6501006420c206222acd449bba45a9c
   GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
   nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
@@ -179,6 +188,6 @@ SPEC CHECKSUMS:
   PurchasesHybridCommon: ecd9d7c586287625f1225b8de5e24c1021502270
   RevenueCat: 9357239a9f0978285e68983637b8a602e65c94f0
 
-PODFILE CHECKSUM: d0c2dd89afcaf8dab1b141712d2c376e9de282d0
+PODFILE CHECKSUM: 21369ea6b0419cdbee9ca38946072d419492de86
 
 COCOAPODS: 1.16.2

--- a/ui/core/src/commonMain/kotlin/br/alexandregpereira/hunter/ui/compose/AppButton.kt
+++ b/ui/core/src/commonMain/kotlin/br/alexandregpereira/hunter/ui/compose/AppButton.kt
@@ -38,6 +38,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -65,11 +67,16 @@ fun AppButton(
             AppButtonSize.SMALL,
             AppButtonSize.MEDIUM -> 16.sp
         }
+        val textDecoration = TextDecoration.Underline.takeIf {
+            type == AppButtonType.TERTIARY
+        }
         Text(
             text = text,
             fontWeight = FontWeight.Normal,
             color = LocalContentColor.current,
             fontSize = fontSizes,
+            textAlign = TextAlign.Center,
+            textDecoration = textDecoration,
             modifier = Modifier.padding(horizontal = 16.dp)
         )
     }


### PR DESCRIPTION
## Implement iOS Ads Consent and Banner UI

- Add `IosAdsConsentManager` using Google's UMP SDK to handle GDPR and privacy consent flows on iOS.
- Implement `AdsBannerView` for iOS using `UIKitView` to display `GADBannerView` with adaptive sizing.
- Integrate CocoaPods support for `core:ads-consent` and `feature:ads:compose` modules.
- Add `Google-Mobile-Ads-SDK` and `GoogleUserMessagingPlatform` dependencies to the iOS project and Podfile.
- Update `IosAppModule` to initialize the `AdsConsentManager` on app startup.
- Configure `Info.plist` with `GADApplicationIdentifier` and `NSUserTrackingUsageDescription`.
- Add Gradle task `UpdateIosVersionTask` to inject the AdMob App ID into iOS xcconfig files.

## Enhance Paywall UI and navigation

- Add "Terms" and "Privacy" buttons to the `PaywallScreen` and update localized strings for English, Portuguese, and Spanish.
- Implement `PaywallViewAction.GoToUrl` to handle external links for legal documents using `LocalUriHandler`.
- Update `PaywallStateHolder` to track analytics events for terms and privacy clicks.
- Refactor `AppButton` to support `TextDecoration.Underline` for tertiary button types.
- Simplify localized strings for the restore button across all supported languages.