### PR TITLE
fix: Challenge rating wrong format on folder detail

### DIFF
--- a/domain/monster-folder/data/build.gradle.kts
+++ b/domain/monster-folder/data/build.gradle.kts
@@ -22,6 +22,7 @@ plugins {
 
 multiplatform {
     commonMain {
+        implementation(project(":domain:monster:core"))
         implementation(project(":domain:monster:data"))
         implementation(project(":domain:monster-folder:core"))
         implementation(project(":domain:settings:core"))

--- a/domain/monster-folder/data/src/commonMain/kotlin/br/alexandregpereira/hunter/data/monster/folder/MonsterFolderEntityMapper.kt
+++ b/domain/monster-folder/data/src/commonMain/kotlin/br/alexandregpereira/hunter/data/monster/folder/MonsterFolderEntityMapper.kt
@@ -24,6 +24,7 @@ import br.alexandregpereira.hunter.domain.folder.model.MonsterFolder
 import br.alexandregpereira.hunter.domain.folder.model.MonsterPreviewFolder
 import br.alexandregpereira.hunter.domain.folder.model.MonsterPreviewFolderImageContentScale
 import br.alexandregpereira.hunter.domain.folder.model.MonsterPreviewFolderType
+import br.alexandregpereira.hunter.domain.model.getChallengeRatingFormatted
 
 internal fun List<MonsterFolderCompleteEntity>.asDomain(
     monsterImageContentScale: MonsterPreviewFolderImageContentScale
@@ -62,14 +63,5 @@ internal fun List<MonsterEntity>.asDomainMonsterPreviewFolderEntity(
                 imageContentScale = imageContentScale,
             )
         }
-    }
-}
-
-private fun Float.getChallengeRatingFormatted(): String {
-    return if (this < 1) {
-        val value = 1 / this
-        "1/${value.toInt()}"
-    } else {
-        this.toInt().toString()
     }
 }


### PR DESCRIPTION
- Remove the local `Float.getChallengeRatingFormatted` extension function from `MonsterFolderEntityMapper.kt` in favor of a shared implementation.
- Update `MonsterFolderEntityMapper.kt` to import `getChallengeRatingFormatted` from the domain model.
- Add `:domain:monster:core` as a dependency to the `:domain:monster-folder:data` module to support the shared formatting logic.

fix #504 