### PR TITLE
Enable parallel sync for Gradle 9.4+

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -28,6 +28,8 @@ org.gradle.jvmargs=-Xmx8g -XX:MaxMetaspaceSize=1g -XX:G1HeapRegionSize=8M -Dfile
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 org.gradle.parallel=true
+# Enabled parallel sync for Gradle 9.4+
+org.gradle.tooling.parallel=true
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app"s APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn


### PR DESCRIPTION
- Add `org.gradle.tooling.parallel=true` to `gradle.properties` to enable parallel sync support for Gradle 9.4 and later.