### PR TITLE
fix(ios): start Ads SDK only after ATT response and serialize consent prompts

### DIFF
--- a/core/ads-consent/src/iosMain/kotlin/br/alexandregpereira/hunter/ads/consent/IosAdsConsentManager.kt
+++ b/core/ads-consent/src/iosMain/kotlin/br/alexandregpereira/hunter/ads/consent/IosAdsConsentManager.kt
@@ -34,6 +34,8 @@ import platform.Foundation.NSError
 import platform.UIKit.UIApplication
 import platform.UIKit.UISceneActivationStateForegroundActive
 import platform.UIKit.UIWindowScene
+import platform.darwin.dispatch_async
+import platform.darwin.dispatch_get_main_queue
 
 @OptIn(ExperimentalForeignApi::class)
 internal class IosAdsConsentManager(
@@ -46,9 +48,17 @@ internal class IosAdsConsentManager(
     private val _canRequestAds = MutableStateFlow(false)
     override val canRequestAds: StateFlow<Boolean> = _canRequestAds.asStateFlow()
 
-    override fun initialize() {
-        GADMobileAds.sharedInstance().startWithCompletionHandler(null)
-    }
+    private var adsSdkStarted = false
+
+    // Both onStart and onResume trigger a consent check, and the App Tracking Transparency alert
+    // itself causes a resign/become active cycle that triggers another one. Without this guard the
+    // UMP form and the ATT prompt end up presented at the same time.
+    private var consentRequestInProgress = false
+
+    // The Google Mobile Ads SDK must not start before the user answers the App Tracking
+    // Transparency prompt, otherwise it loads ad web content and sets tracking cookies while the
+    // authorization status is still undetermined. It is started in finishConsent() instead.
+    override fun initialize() = Unit
 
     override fun showConsentFormIfRequired() {
         requestConsent(shouldShowConsentForm = true)
@@ -59,6 +69,8 @@ internal class IosAdsConsentManager(
     }
 
     private fun requestConsent(shouldShowConsentForm: Boolean) {
+        if (consentRequestInProgress) return
+
         val scene = UIApplication.sharedApplication.connectedScenes
             .filterIsInstance<UIWindowScene>()
             .firstOrNull { it.activationState == UISceneActivationStateForegroundActive }
@@ -70,6 +82,7 @@ internal class IosAdsConsentManager(
             return
         }
 
+        consentRequestInProgress = true
         val params = UMPRequestParameters()
         debugHashedId?.let { hashedId ->
             val debugSettings = UMPDebugSettings()
@@ -81,7 +94,9 @@ internal class IosAdsConsentManager(
             if (error != null) {
                 analytics.logException(Exception(error.localizedDescription))
                 if (shouldShowConsentForm) {
-                    _canRequestAds.value = consentInformation.canRequestAds
+                    onConsentResolved()
+                } else {
+                    publishConsentState()
                 }
                 return@requestConsentInfoUpdateWithParameters
             }
@@ -89,21 +104,47 @@ internal class IosAdsConsentManager(
                 UMPConsentForm.loadAndPresentIfRequiredFromViewController(
                     rootViewController
                 ) { _: NSError? ->
-                    requestAttIfNeeded()
+                    onConsentResolved()
                 }
+            } else {
+                // Ads are not going to be shown, so there is no reason to ask for tracking
+                // authorization or to start the ads SDK.
+                publishConsentState()
             }
         }
     }
 
-    private fun requestAttIfNeeded() {
-        if (ATTrackingManager.trackingAuthorizationStatus ==
+    private fun onConsentResolved() {
+        if (ATTrackingManager.trackingAuthorizationStatus !=
             ATTrackingManagerAuthorizationStatusNotDetermined
         ) {
-            ATTrackingManager.requestTrackingAuthorizationWithCompletionHandler { _ ->
-                _canRequestAds.value = consentInformation.canRequestAds
-            }
-        } else {
-            _canRequestAds.value = consentInformation.canRequestAds
+            finishConsent()
+            return
         }
+        // Give the consent form time to finish dismissing. The ATT alert only presents when no
+        // other modal owns the window, so requesting it too early can make it never appear.
+        dispatch_async(dispatch_get_main_queue()) {
+            ATTrackingManager.requestTrackingAuthorizationWithCompletionHandler { _ ->
+                finishConsent()
+            }
+        }
+    }
+
+    private fun finishConsent() {
+        if (consentInformation.canRequestAds) {
+            startAdsSdkIfNeeded()
+        }
+        publishConsentState()
+    }
+
+    private fun publishConsentState() {
+        consentRequestInProgress = false
+        _canRequestAds.value = consentInformation.canRequestAds
+    }
+
+    private fun startAdsSdkIfNeeded() {
+        if (adsSdkStarted) return
+        adsSdkStarted = true
+        GADMobileAds.sharedInstance().startWithCompletionHandler(null)
     }
 }

--- a/iosApp/MonsterCompendium.xcodeproj/project.pbxproj
+++ b/iosApp/MonsterCompendium.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		82CB83D0D7B909A1A552AC22 /* Pods_MonsterCompendium.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 06FF0B9FED5371FF926A9930 /* Pods_MonsterCompendium.framework */; };
 		C193C3C02F8B03EF00E9D21E /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = C193C3BF2F8B03EF00E9D21E /* GoogleService-Info.plist */; };
+		C1A7700429A00001002F517C /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = C1A7700029A00001002F517C /* InfoPlist.strings */; };
 		C1BC0E8329847A84002F517C /* MonsterCompendiumApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1BC0E8229847A84002F517C /* MonsterCompendiumApp.swift */; };
 		C1BC0E8729847A85002F517C /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C1BC0E8629847A85002F517C /* Assets.xcassets */; };
 		C1BC0E8A29847A85002F517C /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C1BC0E8929847A85002F517C /* Preview Assets.xcassets */; };
@@ -43,6 +44,9 @@
 		C1BC0E8F29847A85002F517C /* MonsterCompendiumTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MonsterCompendiumTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		C1BC0E9929847A85002F517C /* MonsterCompendiumUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MonsterCompendiumUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		C1F8CDFA2F84340800B4A20A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		C1A7700129A00001002F517C /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		C1A7700229A00001002F517C /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
+		C1A7700329A00001002F517C /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -107,6 +111,7 @@
 				C1BC0E8829847A85002F517C /* Preview Content */,
 				C1F8CDFA2F84340800B4A20A /* Info.plist */,
 				C193C3BF2F8B03EF00E9D21E /* GoogleService-Info.plist */,
+				C1A7700029A00001002F517C /* InfoPlist.strings */,
 			);
 			path = MonsterCompendium;
 			sourceTree = "<group>";
@@ -129,6 +134,19 @@
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
+
+/* Begin PBXVariantGroup section */
+		C1A7700029A00001002F517C /* InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				C1A7700129A00001002F517C /* en */,
+				C1A7700229A00001002F517C /* pt-BR */,
+				C1A7700329A00001002F517C /* es */,
+			);
+			name = InfoPlist.strings;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
 
 /* Begin PBXNativeTarget section */
 		C1BC0E7E29847A84002F517C /* MonsterCompendium */ = {
@@ -219,6 +237,7 @@
 			knownRegions = (
 				en,
 				"pt-BR",
+				es,
 				Base,
 			);
 			mainGroup = C1BC0E7629847A83002F517C;
@@ -241,6 +260,7 @@
 				C1BC0E8A29847A85002F517C /* Preview Assets.xcassets in Resources */,
 				C1BC0E8729847A85002F517C /* Assets.xcassets in Resources */,
 				C193C3C02F8B03EF00E9D21E /* GoogleService-Info.plist in Resources */,
+				C1A7700429A00001002F517C /* InfoPlist.strings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iosApp/MonsterCompendium/en.lproj/InfoPlist.strings
+++ b/iosApp/MonsterCompendium/en.lproj/InfoPlist.strings
@@ -1,0 +1,2 @@
+/* Shown in the App Tracking Transparency system prompt. */
+"NSUserTrackingUsageDescription" = "This identifier will be used to deliver personalized ads to you.";

--- a/iosApp/MonsterCompendium/es.lproj/InfoPlist.strings
+++ b/iosApp/MonsterCompendium/es.lproj/InfoPlist.strings
@@ -1,0 +1,2 @@
+/* Shown in the App Tracking Transparency system prompt. */
+"NSUserTrackingUsageDescription" = "Este identificador se usará para mostrarte anuncios personalizados.";

--- a/iosApp/MonsterCompendium/pt-BR.lproj/InfoPlist.strings
+++ b/iosApp/MonsterCompendium/pt-BR.lproj/InfoPlist.strings
@@ -1,0 +1,2 @@
+/* Shown in the App Tracking Transparency system prompt. */
+"NSUserTrackingUsageDescription" = "Este identificador será usado para exibir anúncios personalizados para você.";


### PR DESCRIPTION
## Why

App Review rejected the app: "You collect data to track after the user selects *Ask App Not to Track*... the app accesses web content you own and collects cookies for tracking after the user asked you not to track them."

`initialize()` ran `GADMobileAds.startWithCompletionHandler` from `initKoin()` at app launch, so the Mobile Ads SDK was fully started — loading ad web content and setting cookies — before the UMP form and before the ATT prompt were ever shown. Google's documented iOS order is UMP consent → ATT → then start the SDK.

## What changed

**`IosAdsConsentManager`**

- `initialize()` is now a no-op. The SDK starts in `startAdsSdkIfNeeded()`, called from `finishConsent()` only after the ATT decision is resolved and only when UMP allows. Guarded by `adsSdkStarted` so resume cycles don't restart it.
- `_canRequestAds` is published *after* the SDK start, so the banner can't `loadRequest` against an unstarted SDK.
- Added a `consentRequestInProgress` guard. `onStart()` and `onResume()` both call `checkAdsConsent()`, and on iOS `DisposableEffect` + `UIApplicationDidBecomeActive` fire milliseconds apart at cold launch — two parallel consent chains meant the UMP form and the ATT alert were presented at the same time. The ATT alert's own resign/become-active cycle triggered further rounds.
- ATT is deferred via `dispatch_async(dispatch_get_main_queue())` so the form finishes dismissing first. `requestTrackingAuthorization` only presents when no other modal owns the window, so firing it during dismissal could make the alert never appear.
- Fixed the `loadConsentInfo()` (premium) path, which never published `canRequestAds` on success — `ShouldShowPaywall` suspends on `canRequestAds.firstOrNull { it }` and could hang forever. It deliberately does not request ATT or start the SDK, since premium users see no ads.

**Localized ATT purpose string**

- Added `InfoPlist.strings` for `en`, `pt-BR`, and `es` with a `PBXVariantGroup`, and added `es` to `knownRegions`. The literal string in `Info.plist` remains the fallback.

## Reviewer notes

- Android is unchanged; it has no ATT and `MobileAds.initialize` at app start is fine.
- **Android has the same double-trigger** — `checkAdsConsent()` is common code and `AndroidAdsConsentManager` has no in-flight guard, so `loadAndShowConsentFormIfRequired` can be called twice. Less visible (no system alert) and left out of this PR.
- After an ATT denial the SDK still starts and serves non-personalized ads, driven by UMP's `canRequestAds`. That is permitted under ATT and is correct GDPR/AdMob behavior.
- Adding the `.lproj` folders means the App Store product page will now list English, Portuguese (Brazil), and Spanish as supported languages.

## Testing

Compiles clean (`:core:ads-consent:compileKotlinIosSimulatorArm64`); the Xcode project passes `plutil -lint` and `xcodebuild -list`.

**Not yet verified on a device** — needs a fresh install (`xcrun simctl erase booted`) to confirm no `googleads`/`doubleclick` traffic before the ATT alert, and that the UMP form appears alone with ATT following only after dismissal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
