### PR TITLE
Remove the alternative sources feature flag and gate content on content-sources.json

### DIFF
--- a/app-android/src/main/kotlin/br/alexandregpereira/hunter/app/HunterApplication.kt
+++ b/app-android/src/main/kotlin/br/alexandregpereira/hunter/app/HunterApplication.kt
@@ -20,7 +20,7 @@ package br.alexandregpereira.hunter.app
 import android.app.Application
 import br.alexandregpereira.hunter.ads.consent.AdsConsentManager
 import br.alexandregpereira.hunter.app.di.initKoinModules
-import br.alexandregpereira.hunter.featureFlag.FeatureFlagProvider
+//import br.alexandregpereira.hunter.featureFlag.FeatureFlagProvider
 import com.google.firebase.Firebase
 import com.google.firebase.analytics.analytics
 import com.google.firebase.crashlytics.crashlytics
@@ -33,12 +33,14 @@ import org.koin.dsl.module
 class HunterApplication : Application() {
 
     private val adsConsentManager: AdsConsentManager by inject()
-    private val featureFlagProvider: FeatureFlagProvider by inject()
+    //private val featureFlagProvider: FeatureFlagProvider by inject()
 
     override fun onCreate() {
         super.onCreate()
         initKoin()
-        featureFlagProvider.initialize()
+        // Kept for future flags: there is no consumer right now, so this only spends a
+        // network call on startup. Uncomment when a flag is added back.
+        // featureFlagProvider.initialize()
         adsConsentManager.initialize()
     }
 

--- a/app/src/iosMain/kotlin/br/alexandregpereira/hunter/app/IosAppModule.kt
+++ b/app/src/iosMain/kotlin/br/alexandregpereira/hunter/app/IosAppModule.kt
@@ -19,7 +19,7 @@ package br.alexandregpereira.hunter.app
 
 import br.alexandregpereira.hunter.ads.consent.AdsConsentManager
 import br.alexandregpereira.hunter.app.di.initKoinModules
-import br.alexandregpereira.hunter.featureFlag.FeatureFlagProvider
+//import br.alexandregpereira.hunter.featureFlag.FeatureFlagProvider
 import org.koin.core.Koin
 import org.koin.core.context.startKoin
 
@@ -31,6 +31,8 @@ fun initKoin() {
     koinInstance = startKoin {
         initKoinModules(platformName = "iOS")
     }.koin
-    koinInstance.get<FeatureFlagProvider>().initialize()
+    // Kept for future flags: there is no consumer right now, so this only spends a
+    // network call on startup. Uncomment when a flag is added back.
+    // koinInstance.get<FeatureFlagProvider>().initialize()
     koinInstance.get<AdsConsentManager>().initialize()
 }

--- a/app/src/jvmMain/kotlin/main.kt
+++ b/app/src/jvmMain/kotlin/main.kt
@@ -32,7 +32,7 @@ import br.alexandregpereira.hunter.app.di.initKoinModules
 import br.alexandregpereira.hunter.app.event.AppEventDispatcher
 import br.alexandregpereira.hunter.app.ui.resources.Res
 import br.alexandregpereira.hunter.app.ui.resources.ic_launcher_foreground
-import br.alexandregpereira.hunter.featureFlag.FeatureFlagProvider
+//import br.alexandregpereira.hunter.featureFlag.FeatureFlagProvider
 import br.alexandregpereira.hunter.ui.compose.BackDispatcher
 import br.alexandregpereira.hunter.ui.compose.LocalBackDispatcher
 import org.jetbrains.compose.resources.painterResource
@@ -44,7 +44,9 @@ fun main(args: Array<String>) = application {
         initKoinModules(platformName = "Desktop")
         modules(jvmAnalyticsModule)
     }.koin
-    koin.get<FeatureFlagProvider>().initialize()
+    // Kept for future flags: there is no consumer right now, so this only spends a
+    // network call on startup. Uncomment when a flag is added back.
+    // koin.get<FeatureFlagProvider>().initialize()
     val backDispatcher = JvmBackDispatcher()
     Window(
         onCloseRequest = ::exitApplication,

--- a/core/feature-flag/build.gradle.kts
+++ b/core/feature-flag/build.gradle.kts
@@ -32,6 +32,11 @@ multiplatform {
         implementation(libs.amplitude.experiment.android)
     }
     jvmMain()
+
+    jvmTest {
+        implementation(libs.bundles.unittest)
+    }
+
     iosMain()
 }
 

--- a/core/feature-flag/src/androidMain/kotlin/br/alexandregpereira/hunter/featureFlag/NetworkFailure.android.kt
+++ b/core/feature-flag/src/androidMain/kotlin/br/alexandregpereira/hunter/featureFlag/NetworkFailure.android.kt
@@ -1,0 +1,15 @@
+package br.alexandregpereira.hunter.featureFlag
+
+import java.net.UnknownHostException
+
+internal actual fun Throwable.isNetworkFailure(): Boolean {
+    // The Amplitude SDK wraps it twice in ExecutionException before it reaches us.
+    var current: Throwable? = this
+    var depth = 0
+    while (current != null && depth < MAX_CAUSE_DEPTH) {
+        if (current is UnknownHostException) return true
+        current = current.cause
+        depth++
+    }
+    return false
+}

--- a/core/feature-flag/src/commonMain/kotlin/br/alexandregpereira/hunter/featureFlag/AmplitudeFeatureFlagProvider.kt
+++ b/core/feature-flag/src/commonMain/kotlin/br/alexandregpereira/hunter/featureFlag/AmplitudeFeatureFlagProvider.kt
@@ -59,30 +59,39 @@ internal class AmplitudeFeatureFlagProvider(
                         "cause -> ${cause.message}",
                 cause = cause,
             )
-            analytics.logException(error)
+            logUnlessNetworkFailure(error, cause)
             defaultValue
         }
     }
 
     private fun fetch(client: AmplitudeFeatureFlagClient) {
         scope.launch {
-            fetchSuspending(client)
-        }
-    }
-
-    private suspend fun fetchSuspending(client: AmplitudeFeatureFlagClient) = mutex.withLock {
-        if (!fetched) {
             runCatching {
-                withContext(Dispatchers.IO) { client.fetch() }
-            }.onSuccess {
-                fetched = true
+                fetchSuspending(client)
             }.onFailure { cause ->
                 val error = AmplitudeFeatureFlagProviderException(
                     message = "Failed to fetch the flags, cause -> ${cause.message}",
                     cause = cause,
                 )
-                analytics.logException(error)
+                logUnlessNetworkFailure(error, cause)
             }
+        }
+    }
+
+    private fun logUnlessNetworkFailure(error: Throwable, cause: Throwable) {
+        if (cause.isNetworkFailure()) return
+        analytics.logException(error)
+    }
+
+    /**
+     * Throws when the flags could not be fetched, so that callers can tell a disabled flag apart
+     * from an unknown one and fall back to their default value instead of silently reading an
+     * empty variant.
+     */
+    private suspend fun fetchSuspending(client: AmplitudeFeatureFlagClient) = mutex.withLock {
+        if (!fetched) {
+            withContext(Dispatchers.IO) { client.fetch() }
+            fetched = true
         }
     }
 

--- a/core/feature-flag/src/commonMain/kotlin/br/alexandregpereira/hunter/featureFlag/NetworkFailure.kt
+++ b/core/feature-flag/src/commonMain/kotlin/br/alexandregpereira/hunter/featureFlag/NetworkFailure.kt
@@ -1,0 +1,13 @@
+package br.alexandregpereira.hunter.featureFlag
+
+/**
+ * Whether this was caused by the device not being able to reach the network.
+ *
+ * Such failures say nothing about the app: the flags could not be fetched and the caller already
+ * falls back to its default value. Reporting them only buries the real issues, since
+ * "api.lab.amplitude.com" is on most DNS block lists and a large share of users hit it on every
+ * launch.
+ */
+internal expect fun Throwable.isNetworkFailure(): Boolean
+
+internal const val MAX_CAUSE_DEPTH = 10

--- a/core/feature-flag/src/iosMain/kotlin/br/alexandregpereira/hunter/featureFlag/NetworkFailure.ios.kt
+++ b/core/feature-flag/src/iosMain/kotlin/br/alexandregpereira/hunter/featureFlag/NetworkFailure.ios.kt
@@ -1,0 +1,8 @@
+package br.alexandregpereira.hunter.featureFlag
+
+/**
+ * Always false: [AmplitudeFeatureFlagIosClient] flattens the NSError into a plain Exception holding
+ * only its localizedDescription, so there is no reliable type left to match on. iOS is not a source
+ * of this noise anyway - the Amplitude fetch does not show up in its Crashlytics issues.
+ */
+internal actual fun Throwable.isNetworkFailure(): Boolean = false

--- a/core/feature-flag/src/jvmMain/kotlin/br/alexandregpereira/hunter/featureFlag/NetworkFailure.jvm.kt
+++ b/core/feature-flag/src/jvmMain/kotlin/br/alexandregpereira/hunter/featureFlag/NetworkFailure.jvm.kt
@@ -1,0 +1,14 @@
+package br.alexandregpereira.hunter.featureFlag
+
+import java.net.UnknownHostException
+
+internal actual fun Throwable.isNetworkFailure(): Boolean {
+    var current: Throwable? = this
+    var depth = 0
+    while (current != null && depth < MAX_CAUSE_DEPTH) {
+        if (current is UnknownHostException) return true
+        current = current.cause
+        depth++
+    }
+    return false
+}

--- a/core/feature-flag/src/jvmTest/kotlin/br/alexandregpereira/hunter/featureFlag/AmplitudeFeatureFlagProviderTest.kt
+++ b/core/feature-flag/src/jvmTest/kotlin/br/alexandregpereira/hunter/featureFlag/AmplitudeFeatureFlagProviderTest.kt
@@ -1,0 +1,147 @@
+package br.alexandregpereira.hunter.featureFlag
+
+import br.alexandregpereira.hunter.analytics.Analytics
+import kotlinx.coroutines.test.runTest
+import java.net.UnknownHostException
+import java.util.Collections
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AmplitudeFeatureFlagProviderTest {
+
+    @Test
+    fun `isFeatureEnabled returns the default value when the fetch fails`() = runTest {
+        val analytics = FakeAnalytics()
+        val client = FakeClient(fetchError = RuntimeException("Unable to resolve host"))
+        val provider = createProvider(client, analytics)
+        provider.initialize()
+
+        assertTrue(provider.isFeatureEnabled(feature = FEATURE, defaultValue = true))
+        assertFalse(provider.isFeatureEnabled(feature = FEATURE, defaultValue = false))
+        assertEquals(0, client.variantCallCount)
+        assertTrue(analytics.exceptions.isNotEmpty())
+    }
+
+    @Test
+    fun `isFeatureEnabled does not report the failure when the device has no network`() = runTest {
+        val analytics = FakeAnalytics()
+        val client = FakeClient(fetchError = UnknownHostException("api.lab.amplitude.com"))
+        val provider = createProvider(client, analytics)
+        provider.initialize()
+
+        assertTrue(provider.isFeatureEnabled(feature = FEATURE, defaultValue = true))
+        assertTrue(analytics.exceptions.isEmpty())
+    }
+
+    @Test
+    fun `isFeatureEnabled does not report a network failure wrapped in other exceptions`() = runTest {
+        val analytics = FakeAnalytics()
+        val client = FakeClient(
+            fetchError = ExecutionException(
+                ExecutionException(UnknownHostException("api.lab.amplitude.com"))
+            ),
+        )
+        val provider = createProvider(client, analytics)
+        provider.initialize()
+
+        assertTrue(provider.isFeatureEnabled(feature = FEATURE, defaultValue = true))
+        assertTrue(analytics.exceptions.isEmpty())
+    }
+
+    @Test
+    fun `isFeatureEnabled returns false when the fetch succeeds and the flag is off`() = runTest {
+        val client = FakeClient(variantValue = "off")
+        val provider = createProvider(client)
+        provider.initialize()
+
+        assertFalse(provider.isFeatureEnabled(feature = FEATURE, defaultValue = true))
+    }
+
+    @Test
+    fun `isFeatureEnabled returns true when the fetch succeeds and the flag is on`() = runTest {
+        val client = FakeClient(variantValue = "on")
+        val provider = createProvider(client)
+        provider.initialize()
+
+        assertTrue(provider.isFeatureEnabled(feature = FEATURE, defaultValue = false))
+    }
+
+    @Test
+    fun `isFeatureEnabled retries the fetch after a failure`() = runTest {
+        val client = FakeClient(fetchError = RuntimeException("Unable to resolve host"))
+        val provider = createProvider(client)
+        provider.initialize()
+
+        assertTrue(provider.isFeatureEnabled(feature = FEATURE, defaultValue = true))
+        client.fetchError = null
+        client.variantValue = "on"
+
+        assertTrue(provider.isFeatureEnabled(feature = FEATURE, defaultValue = false))
+    }
+
+    @Test
+    fun `isFeatureEnabled fetches only once after a success`() = runTest {
+        val client = FakeClient(variantValue = "on")
+        val provider = createProvider(client)
+        provider.initialize()
+
+        provider.isFeatureEnabled(feature = FEATURE, defaultValue = false)
+        provider.isFeatureEnabled(feature = FEATURE, defaultValue = false)
+
+        assertEquals(1, client.fetchCallCount)
+    }
+
+    private fun createProvider(
+        client: FakeClient,
+        analytics: Analytics = FakeAnalytics(),
+    ) = AmplitudeFeatureFlagProvider(
+        clientFactory = object : AmplitudeFeatureFlagClient.Factory {
+            override fun create(apiKey: String): AmplitudeFeatureFlagClient = client
+        },
+        apiKey = "any-api-key",
+        analytics = analytics,
+    )
+
+    private class FakeClient(
+        @Volatile var fetchError: Throwable? = null,
+        @Volatile var variantValue: String = "",
+    ) : AmplitudeFeatureFlagClient {
+
+        // The provider fetches from a background scope on initialize, so these are touched
+        // from more than one thread.
+        private val fetchCalls = AtomicInteger(0)
+        private val variantCalls = AtomicInteger(0)
+
+        val fetchCallCount: Int get() = fetchCalls.get()
+        val variantCallCount: Int get() = variantCalls.get()
+
+        override suspend fun fetch() {
+            fetchCalls.incrementAndGet()
+            fetchError?.let { throw it }
+        }
+
+        override fun variant(feature: String): AmplitudeVariant {
+            variantCalls.incrementAndGet()
+            return AmplitudeVariant(value = variantValue)
+        }
+    }
+
+    private class FakeAnalytics : Analytics {
+        val exceptions = Collections.synchronizedList(mutableListOf<Throwable>())
+
+        override fun track(eventName: String, params: Map<String, Any?>) = Unit
+        override fun setUserProperty(name: String, value: Any) = Unit
+        override fun getDeviceId(): String? = null
+        override fun logException(throwable: Throwable) {
+            exceptions += throwable
+        }
+    }
+
+    private companion object {
+        const val FEATURE = "alternative-sources-complete"
+    }
+}

--- a/domain/alternative-source/data/build.gradle.kts
+++ b/domain/alternative-source/data/build.gradle.kts
@@ -22,7 +22,6 @@ plugins {
 
 multiplatform {
     commonMain {
-        implementation(project(":core:feature-flag"))
         implementation(project(":domain:alternative-source:core"))
         implementation(project(":domain:settings:core"))
         implementation(libs.kotlin.coroutines.core)

--- a/domain/alternative-source/data/src/commonMain/kotlin/br/alexandregpereira/hunter/data/source/di/DataModule.kt
+++ b/domain/alternative-source/data/src/commonMain/kotlin/br/alexandregpereira/hunter/data/source/di/DataModule.kt
@@ -53,10 +53,7 @@ val alternativeSourceDataModule = module {
     }
     factory<AlternativeSourceLocalRepository> { AlternativeSourceLocalRepositoryImpl(get()) }
     factory<AlternativeSourceRemoteRepository> {
-        AlternativeSourceRemoteRepositoryImpl(
-            remoteDataSource = get(),
-            featureFlagProvider = get(),
-        )
+        AlternativeSourceRemoteRepositoryImpl(remoteDataSource = get())
     }
     factory<AlternativeSourceSettingsRepository> { AlternativeSourceSettingsRepositoryImpl(get()) }
     factory<GetAlternativeSourcesUseCase> { GetAlternativeSourcesUseCaseImpl(get(), get(), get()) }

--- a/domain/alternative-source/data/src/commonMain/kotlin/br/alexandregpereira/hunter/data/source/remote/AlternativeSourceRemoteDataSource.kt
+++ b/domain/alternative-source/data/src/commonMain/kotlin/br/alexandregpereira/hunter/data/source/remote/AlternativeSourceRemoteDataSource.kt
@@ -22,6 +22,4 @@ import br.alexandregpereira.hunter.data.source.remote.model.AlternativeSourceDto
 internal interface AlternativeSourceRemoteDataSource {
 
     suspend fun getAlternativeSources(lang: String): List<AlternativeSourceDto>
-
-    suspend fun getBasicAlternativeSources(lang: String): List<AlternativeSourceDto>
 }

--- a/domain/alternative-source/data/src/commonMain/kotlin/br/alexandregpereira/hunter/data/source/remote/AlternativeSourceRemoteRepositoryImpl.kt
+++ b/domain/alternative-source/data/src/commonMain/kotlin/br/alexandregpereira/hunter/data/source/remote/AlternativeSourceRemoteRepositoryImpl.kt
@@ -30,7 +30,12 @@ internal class AlternativeSourceRemoteRepositoryImpl(
 ) : AlternativeSourceRemoteRepository {
 
     override fun getAlternativeSources(lang: String): Flow<List<AlternativeSource>> = flow {
-        if (featureFlagProvider.isFeatureEnabled(feature = "alternative-sources-complete")) {
+        // Fails open: hiding content when the flag cannot be resolved is worse than showing it all.
+        if (featureFlagProvider.isFeatureEnabled(
+                feature = "alternative-sources-complete",
+                defaultValue = true,
+            )
+        ) {
             emit(remoteDataSource.getAlternativeSources(lang).toDomain())
         } else {
             emit(remoteDataSource.getBasicAlternativeSources(lang).toDomain())

--- a/domain/alternative-source/data/src/commonMain/kotlin/br/alexandregpereira/hunter/data/source/remote/AlternativeSourceRemoteRepositoryImpl.kt
+++ b/domain/alternative-source/data/src/commonMain/kotlin/br/alexandregpereira/hunter/data/source/remote/AlternativeSourceRemoteRepositoryImpl.kt
@@ -20,25 +20,14 @@ package br.alexandregpereira.hunter.data.source.remote
 import br.alexandregpereira.hunter.data.source.remote.mapper.toDomain
 import br.alexandregpereira.hunter.domain.source.AlternativeSourceRemoteRepository
 import br.alexandregpereira.hunter.domain.source.model.AlternativeSource
-import br.alexandregpereira.hunter.featureFlag.FeatureFlagProvider
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
 internal class AlternativeSourceRemoteRepositoryImpl(
     private val remoteDataSource: AlternativeSourceRemoteDataSource,
-    private val featureFlagProvider: FeatureFlagProvider,
 ) : AlternativeSourceRemoteRepository {
 
     override fun getAlternativeSources(lang: String): Flow<List<AlternativeSource>> = flow {
-        // Fails open: hiding content when the flag cannot be resolved is worse than showing it all.
-        if (featureFlagProvider.isFeatureEnabled(
-                feature = "alternative-sources-complete",
-                defaultValue = true,
-            )
-        ) {
-            emit(remoteDataSource.getAlternativeSources(lang).toDomain())
-        } else {
-            emit(remoteDataSource.getBasicAlternativeSources(lang).toDomain())
-        }
+        emit(remoteDataSource.getAlternativeSources(lang).toDomain())
     }
 }

--- a/domain/alternative-source/data/src/commonMain/kotlin/br/alexandregpereira/hunter/data/source/remote/DefaultAlternativeSourceRemoteDataSource.kt
+++ b/domain/alternative-source/data/src/commonMain/kotlin/br/alexandregpereira/hunter/data/source/remote/DefaultAlternativeSourceRemoteDataSource.kt
@@ -33,10 +33,4 @@ internal class DefaultAlternativeSourceRemoteDataSource(
             client.get(urlString = "$lang/content-sources.json").bodyAsText()
         )
     }
-
-    override suspend fun getBasicAlternativeSources(lang: String): List<AlternativeSourceDto> {
-        return json.decodeFromString(
-            client.get(urlString = "$lang/content-sources-basic.json").bodyAsText()
-        )
-    }
 }

--- a/domain/revenue/mobile/build.gradle.kts
+++ b/domain/revenue/mobile/build.gradle.kts
@@ -23,7 +23,6 @@ plugins {
 multiplatform {
     commonMain {
         implementation(project(":core:analytics"))
-        implementation(project(":core:feature-flag"))
         implementation(project(":domain:revenue:core"))
         implementation(libs.multiplatform.settings)
         implementation(libs.koin.core)

--- a/feature/settings/compose/build.gradle.kts
+++ b/feature/settings/compose/build.gradle.kts
@@ -28,7 +28,6 @@ multiplatform {
         implementation(project(":core:analytics"))
         implementation(project(":core:app-config"))
         implementation(project(":core:event"))
-        implementation(project(":core:feature-flag"))
         implementation(project(":core:localization"))
         implementation(project(":core:state-holder"))
         implementation(project(":domain:alternative-source:core"))


### PR DESCRIPTION
## Problem

A user reported the manage-content screen showing only **3 sources**, while the `alternative-sources-complete` flag was rolled out to 100% in Amplitude.

`AmplitudeFeatureFlagProvider.fetchSuspending` swallowed fetch failures. `isFeatureEnabled` then carried on to `client.variant()`, read an empty variant and returned `false` — so **a failed fetch was indistinguishable from a disabled flag**, and `AlternativeSourceRemoteRepositoryImpl` silently served the basic source list. The `getOrElse` error path in `isFeatureEnabled` was effectively dead code for fetch failures.

Content itself kept loading, which is what made this confusing. It comes from `raw.githubusercontent.com`, while the flag comes from `api.lab.amplitude.com` — a host on most tracker/DNS block lists. Crashlytics over 30 days:

| Host | Issue | Impacted users |
|---|---|---|
| `api.lab.amplitude.com` | `2be2362a…` | **2,784** |
| `raw.githubusercontent.com` (Ktor) | `1046bb42…` | 443 |
| `api.revenuecat.com` | `e20d701b…` | 78 |

If this were plain "user offline", those numbers would track each other. 2,784 vs 443 points at that specific host being blocked.

## Why the flag is removed rather than fixed

The flag existed as a kill switch for copyright takedowns. A client-side flag cannot do that job, because resolving it depends on reaching a host a large share of users block:

- `defaultValue = false` is safe for a takedown, but takes content from ~2,784 users/month who never infringed anything. That was the reported bug.
- `defaultValue = true` fixes those users and **lets exactly the blocked population bypass the takedown**.

There is no correct default. Moving the decision into `content-sources.json` puts the gate on the same host that serves the content: a client that cannot reach it gets no content at all, so the gate cannot be blocked while content still loads.

Takedown propagation verified end to end: `getAlternativeSourcesAdded()` filters against the remote list, so a source dropped from the JSON leaves the sync set; `SyncMonstersUseCase` saves with `isSync = true`, reaching `MonsterDaoImpl.insert(deleteAll = true)`, which wipes it from the local database.

## Changes

**Gate removed.** `AlternativeSourceRemoteRepositoryImpl` always reads `content-sources.json`. `getBasicAlternativeSources` and the `content-sources-basic.json` fetch are gone.

**Dependency cleanup.** `:core:feature-flag` dropped from `:domain:alternative-source:data`, and from `:feature:settings:compose` and `:domain:revenue:mobile` — both declared it without ever referencing it.

**`FeatureFlagProvider.initialize()` commented out** in the three entry points (Android, iOS, JVM). The module is kept for future flags, but with no consumer left the call only spends a startup network request. `app`/`app-android` keep the dependency so uncommenting stays a one-line change.

**Provider hardening kept** (still correct for the next flag):
- `fetchSuspending` propagates the failure so `isFeatureEnabled` reaches `getOrElse` and returns `defaultValue`. Error handling moved into the background `fetch()` launch — that scope has a `SupervisorJob` and no handler, so an uncaught exception there would crash `HunterApplication.onCreate()`.
- `UnknownHostException` is no longer sent to Crashlytics. New `expect fun Throwable.isNetworkFailure()`, applied at both log sites. It walks the cause chain, because the Amplitude SDK wraps it twice in `ExecutionException`. The iOS actual returns `false`: `AmplitudeFeatureFlagIosClient` flattens the `NSError` into a plain `Exception(localizedDescription)`, leaving no reliable type to match.

## Verification

- `:core:feature-flag:jvmTest` 7/7, stable across repeated `--rerun-tasks` runs. `:domain:alternative-source:data` 11/11, `:domain:monster:data` 5/5, `:domain:spell:data` 6/6.
- Compiles clean: `:app:compileKotlinJvm`, `:app:compileKotlinIosSimulatorArm64`, `:app-android:compileDebugKotlin`, plus the two modules that lost the dependency.
- **Pre-existing failure, unrelated:** `linkPodReleaseFrameworkIos*` fails with `ld: framework 'AmplitudeSwift' not found`. Confirmed by stashing that it breaks identically on a clean `main` — CocoaPods setup, not this change.

Expected impact: the ~38k monthly events from `2be2362a…`/`aca43576…` disappear, and every user gets the full compendium regardless of their DNS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
