### PR TITLE
Show a Premium promo banner in the ad slot while the ad is not loaded

### DIFF
--- a/feature/ads/compose/build.gradle.kts
+++ b/feature/ads/compose/build.gradle.kts
@@ -28,6 +28,7 @@ multiplatform {
         implementation(project(":core:ads-consent"))
         implementation(project(":core:analytics"))
         implementation(project(":core:event"))
+        implementation(project(":core:localization"))
         implementation(project(":core:state-holder"))
         implementation(project(":domain:revenue:core"))
         implementation(project(":feature:paywall:event"))
@@ -41,6 +42,10 @@ multiplatform {
         implementation(libs.play.services.ads)
     }
     jvmMain()
+    jvmTest {
+        implementation(libs.bundles.unittest)
+        implementation(project(":core:flow:test"))
+    }
     iosMain()
 }
 

--- a/feature/ads/compose/src/androidMain/kotlin/br/alexandregpereira/hunter/ads/AdsBannerView.android.kt
+++ b/feature/ads/compose/src/androidMain/kotlin/br/alexandregpereira/hunter/ads/AdsBannerView.android.kt
@@ -4,25 +4,38 @@ import android.annotation.SuppressLint
 import android.content.pm.ApplicationInfo
 import android.widget.LinearLayout
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
 import br.alexandregpereira.hunter.ads.consent.AdsConsentManager
+import com.google.android.gms.ads.AdListener
 import com.google.android.gms.ads.AdRequest
 import com.google.android.gms.ads.AdSize
 import com.google.android.gms.ads.AdView
+import com.google.android.gms.ads.LoadAdError
 import org.koin.compose.koinInject
 
 @SuppressLint("MissingPermission")
 @Composable
-internal actual fun AdsBannerView() {
+internal actual fun AdsBannerView(
+    onAdLoaded: () -> Unit,
+    onAdFailedToLoad: () -> Unit,
+) {
     val consentManager: AdsConsentManager = koinInject()
     val canRequestAds by consentManager.canRequestAds.collectAsState()
     val context = LocalContext.current
     val isDebug = context.applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE != 0
+    val currentOnAdLoaded by rememberUpdatedState(onAdLoaded)
+    val currentOnAdFailedToLoad by rememberUpdatedState(onAdFailedToLoad)
 
-    if (!canRequestAds) return
+    if (!canRequestAds) {
+        // Without consent there is no ad to show, so the promo banner takes the slot back.
+        LaunchedEffect(Unit) { currentOnAdFailedToLoad() }
+        return
+    }
 
     AndroidView(
         factory = { ctx ->
@@ -42,8 +55,18 @@ internal actual fun AdsBannerView() {
                     LinearLayout.LayoutParams.MATCH_PARENT,
                     LinearLayout.LayoutParams.WRAP_CONTENT,
                 )
+                adListener = object : AdListener() {
+                    override fun onAdLoaded() {
+                        currentOnAdLoaded()
+                    }
+
+                    override fun onAdFailedToLoad(error: LoadAdError) {
+                        currentOnAdFailedToLoad()
+                    }
+                }
                 loadAd(AdRequest.Builder().build())
             }
         },
+        onRelease = { adView -> adView.destroy() },
     )
 }

--- a/feature/ads/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/ads/AdsBannerTop.kt
+++ b/feature/ads/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/ads/AdsBannerTop.kt
@@ -8,6 +8,7 @@ import androidx.compose.animation.scaleOut
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -44,7 +45,20 @@ fun AdsBannerTop(
             exit = fadeOut() + scaleOut(),
             modifier = Modifier.fillMaxWidth().weight(.1f),
         ) {
-            AdsBannerView()
+            // The promo banner and the ad banner share the same slot and are never rendered at
+            // the same time, so the ad is never covered by the promo.
+            if (state.isPromoBannerVisible) {
+                AdsPromoBanner(
+                    strings = state.strings,
+                    modifier = Modifier.fillMaxSize(),
+                    onClick = stateHolder::onPromoBannerClick,
+                )
+            } else {
+                AdsBannerView(
+                    onAdLoaded = stateHolder::onAdLoaded,
+                    onAdFailedToLoad = stateHolder::onAdFailedToLoad,
+                )
+            }
         }
         val screenSize = LocalScreenSize.current
         val newScreenSize = remember(isBannerVisible, screenSize) {
@@ -66,4 +80,7 @@ fun AdsBannerTop(
 }
 
 @Composable
-internal expect fun AdsBannerView()
+internal expect fun AdsBannerView(
+    onAdLoaded: () -> Unit,
+    onAdFailedToLoad: () -> Unit,
+)

--- a/feature/ads/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/ads/AdsPromoBanner.kt
+++ b/feature/ads/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/ads/AdsPromoBanner.kt
@@ -2,6 +2,7 @@ package br.alexandregpereira.hunter.ads
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -37,15 +38,26 @@ internal fun AdsPromoBanner(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(12.dp),
     ) {
-        Text(
-            text = strings.promoBannerMessage,
+        Column(
             modifier = Modifier.weight(1f),
-            fontSize = 14.sp,
-            lineHeight = 18.sp,
-            fontWeight = FontWeight.Medium,
-            maxLines = 3,
-            overflow = TextOverflow.Ellipsis,
-        )
+            verticalArrangement = Arrangement.spacedBy(2.dp),
+        ) {
+            Text(
+                text = strings.promoBannerTitle,
+                fontSize = 15.sp,
+                lineHeight = 19.sp,
+                fontWeight = FontWeight.Bold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Text(
+                text = strings.promoBannerMessage,
+                fontSize = 13.sp,
+                lineHeight = 17.sp,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
         AppButton(
             text = strings.promoBannerButton,
             modifier = Modifier.width(112.dp),

--- a/feature/ads/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/ads/AdsPromoBanner.kt
+++ b/feature/ads/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/ads/AdsPromoBanner.kt
@@ -1,0 +1,57 @@
+package br.alexandregpereira.hunter.ads
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import br.alexandregpereira.hunter.ui.compose.AppButton
+import br.alexandregpereira.hunter.ui.compose.AppButtonSize
+import br.alexandregpereira.hunter.ui.compose.AppButtonType
+import br.alexandregpereira.hunter.ui.compose.AppSurface
+
+@Composable
+internal fun AdsPromoBanner(
+    strings: AdsStrings,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit = {},
+) = AppSurface(
+    modifier = modifier,
+    color = MaterialTheme.colors.surface,
+) {
+    Row(
+        modifier = Modifier
+            .clickable(onClick = onClick)
+            .fillMaxSize()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Text(
+            text = strings.promoBannerMessage,
+            modifier = Modifier.weight(1f),
+            fontSize = 14.sp,
+            lineHeight = 18.sp,
+            fontWeight = FontWeight.Medium,
+            maxLines = 3,
+            overflow = TextOverflow.Ellipsis,
+        )
+        AppButton(
+            text = strings.promoBannerButton,
+            modifier = Modifier.width(112.dp),
+            size = AppButtonSize.SMALL,
+            type = AppButtonType.PRIMARY,
+            onClick = onClick,
+        )
+    }
+}

--- a/feature/ads/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/ads/AdsState.kt
+++ b/feature/ads/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/ads/AdsState.kt
@@ -2,4 +2,13 @@ package br.alexandregpereira.hunter.ads
 
 internal data class AdsState(
     val isVisible: Boolean = false,
-)
+    val isAdSlotReady: Boolean = false,
+    val strings: AdsStrings = AdsStrings(),
+) {
+
+    val isPromoBannerVisible: Boolean
+        get() = isVisible && isAdSlotReady.not()
+
+    val isAdBannerVisible: Boolean
+        get() = isVisible && isAdSlotReady
+}

--- a/feature/ads/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/ads/AdsStateHolder.kt
+++ b/feature/ads/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/ads/AdsStateHolder.kt
@@ -1,27 +1,39 @@
 package br.alexandregpereira.hunter.ads
 
 import br.alexandregpereira.hunter.analytics.Analytics
+import br.alexandregpereira.hunter.event.v2.EventDispatcher
 import br.alexandregpereira.hunter.event.v2.EventListener
+import br.alexandregpereira.hunter.localization.AppLocalization
+import br.alexandregpereira.hunter.paywall.event.PaywallEvent
 import br.alexandregpereira.hunter.paywall.event.PaywallResult
 import br.alexandregpereira.hunter.revenue.IsPremium
 import br.alexandregpereira.hunter.state.UiModel
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
 
 internal class AdsStateHolder(
     private val isPremium: IsPremium,
     private val paywallResultListener: EventListener<PaywallResult>,
+    private val paywallEventDispatcher: EventDispatcher<PaywallEvent>,
+    private val appLocalization: AppLocalization,
     private val analytics: Analytics,
     private val dispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) : UiModel<AdsState>(AdsState()) {
 
+    private var promoBannerJob: Job? = null
+    private var promoBannerTracked: Boolean = false
+
     fun onStart() {
         checkUsageLimit(trackBannerView = true)
         observeSubscriptionResults()
+        startPromoBannerWindow()
     }
 
     fun checkUsageLimit(trackBannerView: Boolean = false) {
@@ -32,9 +44,50 @@ internal class AdsStateHolder(
                 if (isPremium.not() && trackBannerView) {
                     analytics.track(eventName = "Ads - banner viewed")
                 }
-                setState { copy(isVisible = isPremium.not()) }
+                setState {
+                    copy(
+                        isVisible = isPremium.not(),
+                        strings = appLocalization.getAdsStrings(),
+                    )
+                }
             }
             .launchIn(scope)
+    }
+
+    /**
+     * The ad banner is only composed after the promo banner has been on screen for
+     * [PROMO_BANNER_MIN_DURATION_IN_MILLIS]. Both banners share the same slot and are never
+     * rendered at the same time, so the ad is never covered by the promo. When the ad fails to
+     * load, which is what happens when the user has an ad blocker, the promo banner comes back
+     * and the ad is requested again only after [PROMO_BANNER_RETRY_DURATION_IN_MILLIS].
+     */
+    fun onAdFailedToLoad() {
+        analytics.track(eventName = "Ads - banner load failed")
+        startPromoBannerWindow(durationInMillis = PROMO_BANNER_RETRY_DURATION_IN_MILLIS)
+    }
+
+    fun onAdLoaded() {
+        analytics.track(eventName = "Ads - banner loaded")
+    }
+
+    fun onPromoBannerClick() {
+        analytics.track(eventName = "Ads - promo banner clicked")
+        paywallEventDispatcher.dispatchEvent(PaywallEvent.ShowPaywall)
+    }
+
+    private fun startPromoBannerWindow(
+        durationInMillis: Long = PROMO_BANNER_MIN_DURATION_IN_MILLIS,
+    ) {
+        promoBannerJob?.cancel()
+        promoBannerJob = scope.launch {
+            setState { copy(isAdSlotReady = false) }
+            if (promoBannerTracked.not()) {
+                promoBannerTracked = true
+                analytics.track(eventName = "Ads - promo banner viewed")
+            }
+            delay(durationInMillis)
+            setState { copy(isAdSlotReady = true) }
+        }
     }
 
     private fun observeSubscriptionResults() {
@@ -43,6 +96,7 @@ internal class AdsStateHolder(
                 when (result) {
                     PaywallResult.OnSubscribe -> {
                         analytics.track(eventName = "Ads - banner closed")
+                        promoBannerJob?.cancel()
                         setState { copy(isVisible = false) }
                     }
                 }
@@ -50,3 +104,6 @@ internal class AdsStateHolder(
             .launchIn(scope)
     }
 }
+
+private const val PROMO_BANNER_MIN_DURATION_IN_MILLIS = 15_000L
+private const val PROMO_BANNER_RETRY_DURATION_IN_MILLIS = 60_000L

--- a/feature/ads/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/ads/AdsStrings.kt
+++ b/feature/ads/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/ads/AdsStrings.kt
@@ -4,22 +4,26 @@ import br.alexandregpereira.hunter.localization.AppLocalization
 import br.alexandregpereira.hunter.localization.Language
 
 internal interface AdsStrings {
+    val promoBannerTitle: String
     val promoBannerMessage: String
     val promoBannerButton: String
 }
 
 internal data class AdsEnUsStrings(
-    override val promoBannerMessage: String = "Claim this screen space by subscribing to Premium and removing ads",
+    override val promoBannerTitle: String = "Subscribe to Premium",
+    override val promoBannerMessage: String = "Claim this screen space and remove the ads",
     override val promoBannerButton: String = "Subscribe",
 ) : AdsStrings
 
 internal data class AdsPtBrStrings(
-    override val promoBannerMessage: String = "Reivindique esse espaço da tela assinando o Premium e removendo os anúncios",
+    override val promoBannerTitle: String = "Assine o plano Premium",
+    override val promoBannerMessage: String = "Reivindique esse espaço da tela e remova os anúncios",
     override val promoBannerButton: String = "Assinar",
 ) : AdsStrings
 
 internal data class AdsEsStrings(
-    override val promoBannerMessage: String = "Reclama este espacio de la pantalla suscribiéndote a Premium y eliminando los anuncios",
+    override val promoBannerTitle: String = "Suscríbete al plan Premium",
+    override val promoBannerMessage: String = "Reclama este espacio de la pantalla y elimina los anuncios",
     override val promoBannerButton: String = "Suscribirse",
 ) : AdsStrings
 

--- a/feature/ads/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/ads/AdsStrings.kt
+++ b/feature/ads/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/ads/AdsStrings.kt
@@ -1,0 +1,34 @@
+package br.alexandregpereira.hunter.ads
+
+import br.alexandregpereira.hunter.localization.AppLocalization
+import br.alexandregpereira.hunter.localization.Language
+
+internal interface AdsStrings {
+    val promoBannerMessage: String
+    val promoBannerButton: String
+}
+
+internal data class AdsEnUsStrings(
+    override val promoBannerMessage: String = "Claim this screen space by subscribing to Premium and removing ads",
+    override val promoBannerButton: String = "Subscribe",
+) : AdsStrings
+
+internal data class AdsPtBrStrings(
+    override val promoBannerMessage: String = "Reivindique esse espaço da tela assinando o Premium e removendo os anúncios",
+    override val promoBannerButton: String = "Assinar",
+) : AdsStrings
+
+internal data class AdsEsStrings(
+    override val promoBannerMessage: String = "Reclama este espacio de la pantalla suscribiéndote a Premium y eliminando los anuncios",
+    override val promoBannerButton: String = "Suscribirse",
+) : AdsStrings
+
+internal fun AdsStrings(): AdsStrings = AdsEnUsStrings()
+
+internal fun AppLocalization.getAdsStrings(): AdsStrings {
+    return when (getLanguage()) {
+        Language.ENGLISH -> AdsEnUsStrings()
+        Language.PORTUGUESE -> AdsPtBrStrings()
+        Language.SPANISH -> AdsEsStrings()
+    }
+}

--- a/feature/ads/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/ads/di/FeatureModule.kt
+++ b/feature/ads/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/ads/di/FeatureModule.kt
@@ -1,6 +1,7 @@
 package br.alexandregpereira.hunter.ads.di
 
 import br.alexandregpereira.hunter.ads.AdsStateHolder
+import br.alexandregpereira.hunter.paywall.event.PaywallEventDispatcher
 import br.alexandregpereira.hunter.paywall.event.PaywallResultDispatcher
 import org.koin.dsl.module
 
@@ -9,6 +10,8 @@ val adsFeatureModule = module {
         AdsStateHolder(
             isPremium = get(),
             paywallResultListener = get<PaywallResultDispatcher>(),
+            paywallEventDispatcher = get<PaywallEventDispatcher>(),
+            appLocalization = get(),
             analytics = get(),
         )
     }

--- a/feature/ads/compose/src/iosMain/kotlin/br/alexandregpereira/hunter/ads/AdsBannerView.ios.kt
+++ b/feature/ads/compose/src/iosMain/kotlin/br/alexandregpereira/hunter/ads/AdsBannerView.ios.kt
@@ -18,31 +18,62 @@
 package br.alexandregpereira.hunter.ads
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.viewinterop.UIKitView
 import br.alexandregpereira.hunter.ads.consent.AdsConsentManager
 import cocoapods.Google_Mobile_Ads_SDK.GADBannerView
+import cocoapods.Google_Mobile_Ads_SDK.GADBannerViewDelegateProtocol
 import cocoapods.Google_Mobile_Ads_SDK.GADLargeAnchoredAdaptiveBannerAdSizeWithWidth
 import cocoapods.Google_Mobile_Ads_SDK.GADRequest
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.useContents
 import org.koin.compose.koinInject
+import platform.Foundation.NSError
 import platform.UIKit.UIApplication
 import platform.UIKit.UISceneActivationStateForegroundActive
 import platform.UIKit.UIScreen
 import platform.UIKit.UIWindowScene
+import platform.darwin.NSObject
 
 @OptIn(ExperimentalForeignApi::class, kotlin.experimental.ExperimentalNativeApi::class)
 @Composable
-internal actual fun AdsBannerView() {
+internal actual fun AdsBannerView(
+    onAdLoaded: () -> Unit,
+    onAdFailedToLoad: () -> Unit,
+) {
     val consentManager: AdsConsentManager = koinInject()
     val canRequestAds by consentManager.canRequestAds.collectAsState()
-    val adLoaded = remember { mutableStateOf(false) }
+    val adRequested = remember { mutableStateOf(false) }
+    val currentOnAdLoaded by rememberUpdatedState(onAdLoaded)
+    val currentOnAdFailedToLoad by rememberUpdatedState(onAdFailedToLoad)
 
-    // UIKitView is always composed so factory runs at app startup when the scene is stable.
+    // GADBannerView holds the delegate weakly, so it has to be kept alive by the composition.
+    val delegate = remember {
+        object : NSObject(), GADBannerViewDelegateProtocol {
+            override fun bannerViewDidReceiveAd(bannerView: GADBannerView) {
+                currentOnAdLoaded()
+            }
+
+            override fun bannerView(
+                bannerView: GADBannerView,
+                didFailToReceiveAdWithError: NSError,
+            ) {
+                currentOnAdFailedToLoad()
+            }
+        }
+    }
+
+    if (!canRequestAds) {
+        // Without consent there is no ad to show, so the promo banner takes the slot back.
+        LaunchedEffect(Unit) { currentOnAdFailedToLoad() }
+        return
+    }
+
     // loadRequest is deferred to update() to avoid a timing issue where the scene is briefly
     // inactive during the UMP/ATT consent modal dismissal animation.
     UIKitView(
@@ -62,12 +93,18 @@ internal actual fun AdsBannerView() {
                     "ca-app-pub-9186388258407371/2524216431"
                 }
                 this.rootViewController = rootViewController
+                this.delegate = delegate
             }
         },
         update = { bannerView ->
-            if (canRequestAds && !adLoaded.value && bannerView.adUnitID != null) {
-                bannerView.loadRequest(GADRequest.request())
-                adLoaded.value = true
+            if (adRequested.value.not()) {
+                adRequested.value = true
+                if (bannerView.adUnitID == null) {
+                    // There was no active scene when the banner was created.
+                    currentOnAdFailedToLoad()
+                } else {
+                    bannerView.loadRequest(GADRequest.request())
+                }
             }
         },
     )

--- a/feature/ads/compose/src/jvmMain/kotlin/br/alexandregpereira/hunter/ads/AdsBannerView.jvm.kt
+++ b/feature/ads/compose/src/jvmMain/kotlin/br/alexandregpereira/hunter/ads/AdsBannerView.jvm.kt
@@ -1,8 +1,16 @@
 package br.alexandregpereira.hunter.ads
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
 
 @Composable
-internal actual fun AdsBannerView() {
-    // No-op on JVM/Desktop
+internal actual fun AdsBannerView(
+    onAdLoaded: () -> Unit,
+    onAdFailedToLoad: () -> Unit,
+) {
+    // There is no ad SDK on JVM/Desktop, so the promo banner takes the slot back.
+    val currentOnAdFailedToLoad by rememberUpdatedState(onAdFailedToLoad)
+    LaunchedEffect(Unit) { currentOnAdFailedToLoad() }
 }

--- a/feature/ads/compose/src/jvmTest/kotlin/br/alexandregpereira/hunter/ads/AdsStateHolderTest.kt
+++ b/feature/ads/compose/src/jvmTest/kotlin/br/alexandregpereira/hunter/ads/AdsStateHolderTest.kt
@@ -1,0 +1,159 @@
+package br.alexandregpereira.hunter.ads
+
+import br.alexandregpereira.hunter.analytics.Analytics
+import br.alexandregpereira.hunter.localization.AppLocalization
+import br.alexandregpereira.hunter.localization.Language
+import br.alexandregpereira.hunter.paywall.event.PaywallEvent
+import br.alexandregpereira.hunter.paywall.event.PaywallEventDispatcher
+import br.alexandregpereira.hunter.paywall.event.PaywallResult
+import br.alexandregpereira.hunter.paywall.event.PaywallResultDispatcher
+import br.alexandregpereira.hunter.revenue.IsPremium
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class AdsStateHolderTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val paywallResultDispatcher = PaywallResultDispatcher()
+    private val paywallEventDispatcher = PaywallEventDispatcher()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `promo banner is shown instead of the ad banner when the app starts`() = runTest {
+        val stateHolder = createStateHolder()
+
+        stateHolder.onStart()
+        runCurrent()
+
+        assertTrue(stateHolder.state.value.isPromoBannerVisible)
+        assertFalse(stateHolder.state.value.isAdBannerVisible)
+    }
+
+    @Test
+    fun `ad banner replaces the promo banner after the promo minimum duration`() = runTest {
+        val stateHolder = createStateHolder()
+
+        stateHolder.onStart()
+        advanceTimeBy(14_999)
+
+        assertTrue(stateHolder.state.value.isPromoBannerVisible)
+
+        advanceTimeBy(2)
+
+        assertTrue(stateHolder.state.value.isAdBannerVisible)
+        assertFalse(stateHolder.state.value.isPromoBannerVisible)
+    }
+
+    @Test
+    fun `promo banner comes back when the ad fails to load`() = runTest {
+        val stateHolder = createStateHolder()
+
+        stateHolder.onStart()
+        advanceTimeBy(15_001)
+        stateHolder.onAdFailedToLoad()
+        runCurrent()
+
+        assertTrue(stateHolder.state.value.isPromoBannerVisible)
+        assertFalse(stateHolder.state.value.isAdBannerVisible)
+    }
+
+    @Test
+    fun `ad is requested again only after the retry duration`() = runTest {
+        val stateHolder = createStateHolder()
+
+        stateHolder.onStart()
+        advanceTimeBy(15_001)
+        stateHolder.onAdFailedToLoad()
+        advanceTimeBy(59_999)
+
+        assertTrue(stateHolder.state.value.isPromoBannerVisible)
+
+        advanceTimeBy(2)
+
+        assertTrue(stateHolder.state.value.isAdBannerVisible)
+    }
+
+    @Test
+    fun `no banner is shown when the user is premium`() = runTest {
+        val stateHolder = createStateHolder(isPremium = true)
+
+        stateHolder.onStart()
+        advanceUntilIdle()
+
+        assertFalse(stateHolder.state.value.isPromoBannerVisible)
+        assertFalse(stateHolder.state.value.isAdBannerVisible)
+    }
+
+    @Test
+    fun `banners are hidden after a subscription`() = runTest {
+        val stateHolder = createStateHolder()
+
+        stateHolder.onStart()
+        advanceUntilIdle()
+        paywallResultDispatcher.dispatchEvent(PaywallResult.OnSubscribe)
+        advanceUntilIdle()
+
+        assertFalse(stateHolder.state.value.isVisible)
+        assertFalse(stateHolder.state.value.isPromoBannerVisible)
+        assertFalse(stateHolder.state.value.isAdBannerVisible)
+    }
+
+    @Test
+    fun `promo banner click opens the paywall`() = runTest {
+        val stateHolder = createStateHolder()
+        var event: PaywallEvent? = null
+        val job = launch { event = paywallEventDispatcher.events.first() }
+        advanceUntilIdle()
+
+        stateHolder.onPromoBannerClick()
+        advanceUntilIdle()
+
+        assertEquals(PaywallEvent.ShowPaywall, event)
+        job.cancel()
+    }
+
+    private fun createStateHolder(
+        isPremium: Boolean = false,
+    ): AdsStateHolder = AdsStateHolder(
+        isPremium = IsPremium { isPremium },
+        paywallResultListener = paywallResultDispatcher,
+        paywallEventDispatcher = paywallEventDispatcher,
+        appLocalization = object : AppLocalization {
+            override fun getLanguage(): Language = Language.ENGLISH
+        },
+        analytics = FakeAnalytics(),
+        dispatcher = testDispatcher,
+    )
+}
+
+private class FakeAnalytics : Analytics {
+    override fun track(eventName: String, params: Map<String, Any?>) = Unit
+    override fun setUserProperty(name: String, value: Any) = Unit
+    override fun getDeviceId(): String? = null
+    override fun logException(throwable: Throwable) = Unit
+}


### PR DESCRIPTION
## Why

A relevant share of users runs ad blockers, and there are also cases where the ad simply never loads (no consent, no network, SDK timeout). In all of those cases the banner slot at the top of the screen stayed empty, wasting 10% of the screen and earning nothing.

This change fills that slot with a Premium promo banner, turning blocked/failed ad impressions into a subscription pitch.

## What changed

**Behavior**

- On app start the promo banner is shown for a minimum of **15s**. Only then is `AdsBannerView` composed and the ad requested.
- If the ad loads, it takes the slot. If it fails to load — the ad blocker case — the promo comes back and the ad is only requested again after **60s**, so blocked users don't trigger a request every few seconds.
- The promo and the ad **never render at the same time**: they alternate in the same slot. That avoids the AdMob "obscured ad" policy problem an overlay would create, and avoids layout shift (the slot is already reserved).
- Tapping the promo (anywhere on the row, or the button) dispatches `PaywallEvent.ShowPaywall`, the same path the settings screen already uses.
- On JVM/Desktop there is no ad SDK, so the platform actual reports a load failure immediately and the promo owns the slot — previously that slot was just empty there.

**Code**

- `AdsStrings.kt` (new): per-feature typed strings in en/pt-BR/es, following the project's `*Strings.kt` convention.
- `AdsPromoBanner.kt` (new): title + message + `AppButton`, built from `ui:core` components.
- `AdsState`: adds `isAdSlotReady` plus derived `isPromoBannerVisible` / `isAdBannerVisible`.
- `AdsStateHolder`: owns the promo window, the retry window, the paywall dispatch, and localized strings.
- `AdsBannerView` expect/actual now takes `onAdLoaded` / `onAdFailedToLoad`. Android wires them through `AdListener` (and adds `onRelease { destroy() }`); iOS through `GADBannerViewDelegateProtocol`, kept alive in `remember` because `GADBannerView` holds its delegate weakly.
- Ads module now depends on `:core:localization`, and gains a `jvmTest` source set.

**Analytics** — new events to measure how big the ad-blocked audience is and whether the promo converts: `Ads - promo banner viewed` (once per session), `Ads - promo banner clicked`, `Ads - banner loaded`, `Ads - banner load failed`.

## Notes for the reviewer

- The 15s / 60s constants live at the bottom of `AdsStateHolder.kt` and are easy to tune once the analytics come in.
- 7 new tests in `AdsStateHolderTest` cover the timing, the transitions, the premium/subscription cases, and the paywall dispatch: `./gradlew :feature:ads:compose:jvmTest` passes.
- Android, JVM and iOS all compile. `linkPodReleaseFrameworkIosArm64` fails locally with `framework 'AmplitudeSwift' not found`, but it fails the same way on `main` — it's a local CocoaPods setup issue, not from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)