### PR TITLE
Shrink the promo banner text when it does not fit the banner slot

### DIFF
--- a/feature/ads/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/ads/AdsPromoBanner.kt
+++ b/feature/ads/compose/src/commonMain/kotlin/br/alexandregpereira/hunter/ads/AdsPromoBanner.kt
@@ -10,10 +10,16 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import br.alexandregpereira.hunter.ui.compose.AppButton
@@ -34,7 +40,7 @@ internal fun AdsPromoBanner(
         modifier = Modifier
             .clickable(onClick = onClick)
             .fillMaxSize()
-            .padding(horizontal = 16.dp, vertical = 8.dp),
+            .padding(horizontal = 12.dp, vertical = 6.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(12.dp),
     ) {
@@ -42,20 +48,18 @@ internal fun AdsPromoBanner(
             modifier = Modifier.weight(1f),
             verticalArrangement = Arrangement.spacedBy(2.dp),
         ) {
-            Text(
+            AutoSizeText(
                 text = strings.promoBannerTitle,
-                fontSize = 15.sp,
-                lineHeight = 19.sp,
-                fontWeight = FontWeight.Bold,
+                maxFontSize = 15.sp,
+                minFontSize = 11.sp,
                 maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
+                fontWeight = FontWeight.Bold,
             )
-            Text(
+            AutoSizeText(
                 text = strings.promoBannerMessage,
-                fontSize = 13.sp,
-                lineHeight = 17.sp,
+                maxFontSize = 13.sp,
+                minFontSize = 9.sp,
                 maxLines = 2,
-                overflow = TextOverflow.Ellipsis,
             )
         }
         AppButton(
@@ -67,3 +71,44 @@ internal fun AdsPromoBanner(
         )
     }
 }
+
+/**
+ * The banner slot height is a fraction of the screen height, so the text does not always fit in
+ * [maxLines], specially when the device is using a bigger font scale. The font size is decreased
+ * until the text fits or until [minFontSize] is reached.
+ */
+@Composable
+private fun AutoSizeText(
+    text: String,
+    maxFontSize: TextUnit,
+    minFontSize: TextUnit,
+    maxLines: Int,
+    modifier: Modifier = Modifier,
+    fontWeight: FontWeight? = null,
+) {
+    var fontSize by remember(text, maxFontSize) { mutableStateOf(maxFontSize) }
+    var isTextMeasured by remember(text, maxFontSize) { mutableStateOf(false) }
+
+    Text(
+        text = text,
+        modifier = modifier.drawWithContent {
+            if (isTextMeasured) drawContent()
+        },
+        fontSize = fontSize,
+        lineHeight = fontSize * LINE_HEIGHT_RATIO,
+        fontWeight = fontWeight,
+        maxLines = maxLines,
+        overflow = TextOverflow.Ellipsis,
+        onTextLayout = { textLayoutResult ->
+            if (textLayoutResult.hasVisualOverflow && fontSize > minFontSize) {
+                fontSize = (fontSize.value - FONT_SIZE_STEP)
+                    .coerceAtLeast(minFontSize.value).sp
+            } else {
+                isTextMeasured = true
+            }
+        },
+    )
+}
+
+private const val LINE_HEIGHT_RATIO = 1.3f
+private const val FONT_SIZE_STEP = 0.5f


### PR DESCRIPTION
Follow-up to #519.

## Why

The ad/promo slot height is a fraction of the screen height, while the banner texts are sized in `sp`. On a device using a bigger font scale — reported on a Galaxy S23 — the title plus two lines of the message no longer fit the slot, and the `Column` truncated the message to a single ellipsized line.

## What changed

- New private `AutoSizeText` in `AdsPromoBanner.kt`: while `TextLayoutResult.hasVisualOverflow` is true (height overflow or `maxLines` truncation), it decreases the font size in 0.5sp steps down to a minimum. The loop is monotonic and stops at the minimum, so it always terminates.
- Applied to the promo banner title (15sp → 11sp, 1 line) and message (13sp → 9sp, 2 lines).
- The text is only drawn after the final measurement (`drawWithContent` gated by a flag), so there is no visible font-size jump on the first frame.
- Banner padding reduced from 16/8dp to 12/6dp, giving the texts more room before they have to shrink at all.

Because `Column` measures the message with the height left over after the title, the message adapts to whatever space the slot actually has, at any font scale.

## Notes for the reviewer

- Android, JVM and iOS all compile; `:feature:ads:compose:jvmTest` still passes (the existing tests cover the state holder, not this layout).
- I could not verify this one visually: screen capture is not permitted on this machine, and the local iOS link still fails with the pre-existing `framework 'AmplitudeSwift' not found`. Worth a look on a device with the font scale turned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)